### PR TITLE
Enable template field locking

### DIFF
--- a/shared/shared/core/key_types.py
+++ b/shared/shared/core/key_types.py
@@ -16,9 +16,9 @@ class KEY_TYPE:
     COLLECTIONFIELD = 3
 
 
-_collection_regex = "[a-z]+|[a-z][a-z_]+[a-z]"
-_id_regex = "[1-9][0-9]*"
-_field_regex = "[a-z][a-z0-9_]*"
+_collection_regex = r"[a-z]+|[a-z][a-z_]+[a-z]"
+_id_regex = r"[1-9][0-9]*"
+_field_regex = r"[a-z][a-z0-9_]*\$?[a-z0-9_]*"
 
 fqid_regex = re.compile(f"^({_collection_regex}){KEYSEPARATOR}({_id_regex})$")
 fqfield_regex = re.compile(

--- a/shared/tests/unit/core/test_key_types.py
+++ b/shared/tests/unit/core/test_key_types.py
@@ -57,19 +57,26 @@ no_fqids = (
     "collection_/482",
     "collection/0",
     "collection/96e2",
+    "collection/1$2",
     "collection_/593",
     "some string without a slash",
+    "collection$string/1",
+    "collection1/1",
 )
 no_fqfields = (
     "collection/493/_field",
     "_collection/493/field",
     "collection/493/_field",
     "collection/29/1field",
+    "collection/1/$field",
+    "collection/1/field_$_$_suffix",
 )
 no_collectionfields = (
     "_collection/field",
     "collection/4_field",
     "collection/my_\u0394_unicode_field",
+    "collection/$field",
+    "collection/field_$_$_suffix",
 )
 
 all_keys = no_fqids + no_fqfields + no_collectionfields
@@ -123,3 +130,7 @@ def test_id():
 
 def test_field():
     assert_is_field("my_field_2_")
+
+
+def test_field_template():
+    assert_is_field("f_$_s")

--- a/writer/tests/system/write/test_occ_locking.py
+++ b/writer/tests/system/write/test_occ_locking.py
@@ -140,3 +140,39 @@ def test_lock_collectionfield_not_ok(json_client, data):
     response = json_client.post(WRITE_URL, data)
     assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
     assert_no_model("a/2")
+
+
+def test_lock_fqfield_template(json_client, data):
+    create_and_update_model(json_client, "a/1", {"f_1_s": 1}, {"f_1_s": 2})
+    data["locked_fields"]["a/1/f_$_s"] = 1
+
+    response = json_client.post(WRITE_URL, data)
+    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
+    assert_no_model("a/2")
+
+
+def test_lock_fqfield_template_dollar_sign(json_client, data):
+    create_and_update_model(json_client, "a/1", {"f_$_s": 1}, {"f_$_s": 2})
+    data["locked_fields"]["a/1/f_$_s"] = 1
+
+    response = json_client.post(WRITE_URL, data)
+    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
+    assert_no_model("a/2")
+
+
+def test_lock_fqfield_template_two_placeholders(json_client, data):
+    create_and_update_model(json_client, "a/1", {"f_1_2_s": 1}, {"f_1_2_s": 2})
+    data["locked_fields"]["a/1/f_$_$_s"] = 1
+
+    response = json_client.post(WRITE_URL, data)
+    assert_error_response(response, ERROR_CODES.INVALID_FORMAT)
+    assert_no_model("a/2")
+
+
+def test_lock_fqfield_template_empty_placeholder(json_client, data):
+    create_and_update_model(json_client, "a/1", {"f__s": 1}, {"f__s": 2})
+    data["locked_fields"]["a/1/f_$_s"] = 1
+
+    response = json_client.post(WRITE_URL, data)
+    assert response.status_code == 200
+    assert_model("a/2", {}, 3)

--- a/writer/tests/unit/postgresql_backend/test_sql_occ_locker_backend_service.py
+++ b/writer/tests/unit/postgresql_backend/test_sql_occ_locker_backend_service.py
@@ -76,7 +76,7 @@ def test_query_arguments_fqfield(occ_locker, connection):
 
     query = qsv.call_args.args[0]
     assert query.count("(fqid=%s and position>%s)") == 2
-    assert query.count("(e.fqid=%s and cf.collectionfield=%s)") == 2
+    assert query.count("(e.fqid=%s and cf.collectionfield LIKE %s)") == 2
     args = qsv.call_args.args[1]
     assert (args == ["a/1", 2, "b/3", 42, "a/1", "a/f", "b/3", "b/e"]) or (
         args == ["b/3", 42, "a/1", 2, "b/3", "b/e", "a/1", "a/f"]

--- a/writer/writer/postgresql_backend/sql_occ_locker_backend_service.py
+++ b/writer/writer/postgresql_backend/sql_occ_locker_backend_service.py
@@ -48,8 +48,15 @@ class SqlOccLockerBackendService:
             event_query_arguments.extend((fqid, position,))
             event_filter_parts.append("(fqid=%s and position>%s)")
 
+            print(collectionfield)
+            collectionfield = collectionfield.replace("_", r"\_")
+            collectionfield = collectionfield.replace("$", "_%")
+            print(collectionfield)
+
             collectionfield_query_arguments.extend((fqid, collectionfield,))
-            collectionfield_filter_parts.append("(e.fqid=%s and cf.collectionfield=%s)")
+            collectionfield_filter_parts.append(
+                "(e.fqid=%s and cf.collectionfield LIKE %s)"
+            )
 
         event_filter = " or ".join(event_filter_parts)
         collectionfield_filter = " or ".join(collectionfield_filter_parts)


### PR DESCRIPTION
(Deprecated) See #10
Locking a field in the fashion of `f_$_s` locks all fields matching the regex `f_.*_s`