### PR TITLE
Example data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ run-integration-unit-tests-interactive: | build-tests
 	docker run -ti -p 5000:5000 -v `pwd`/shared/shared:/app/shared -v `pwd`/$(MODULE)/$(MODULE):/app/$(MODULE) -v `pwd`/$(MODULE)/tests:/app/tests openslides-datastore-$(MODULE)-test bash
 
 run-cleanup: | build-tests
-	docker run -ti -v `pwd`/shared/shared:/app/shared -v `pwd`/$(MODULE)/$(MODULE):/app/$(MODULE) -v `pwd`/$(MODULE)/tests:/app/tests openslides-datastore-$(MODULE)-test ./cleanup.sh
+	docker run -ti -v `pwd`/shared/shared:/app/shared -v `pwd`/$(MODULE)/$(MODULE):/app/$(MODULE) -v `pwd`/$(MODULE)/tests:/app/tests -v `pwd`/cli:/app/cli openslides-datastore-$(MODULE)-test ./cleanup.sh
 
 # Docker compose
 setup-docker-compose: | build-tests

--- a/cli/create_initial_data.py
+++ b/cli/create_initial_data.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from typing import List
+from urllib import request
+
+from shared.di import injector
+from shared.postgresql_backend import ConnectionHandler
+from shared.util import build_fqid
+from writer.app import register_services
+from writer.core import BaseRequestEvent, RequestCreateEvent, Writer, WriteRequest
+
+
+register_services()
+connection: ConnectionHandler = injector.get(ConnectionHandler)
+writer: Writer = injector.get(Writer)
+
+with connection.get_connection_context():
+    events_count = connection.query_single_value(
+        "SELECT COUNT(*) FROM events LIMIT 1", []
+    )
+    if events_count:
+        if len(sys.argv) > 1 and sys.argv[1] == "-f":
+            print("Warning: database is not empty! Executing anyway...")
+        else:
+            print(
+                "Error: Some events are already present, aborting.\
+                If you wish to continue anyway, re-run with '-f'."
+            )
+            sys.exit(1)
+
+raw = request.urlopen(
+    "https://raw.githubusercontent.com/OpenSlides/OpenSlides/openslides4-dev/docs/example-data.json"  # noqa
+).read()
+data = json.loads(raw)
+
+events: List[BaseRequestEvent] = []
+for collection, models in data.items():
+    for model in models:
+        fqid = build_fqid(collection, model["id"])
+        event = RequestCreateEvent(fqid, model)
+        events.append(event)
+
+write_request = WriteRequest(events, None, 0, {})
+writer.write(write_request)

--- a/dc.test.yml
+++ b/dc.test.yml
@@ -7,6 +7,7 @@ services:
             - ./shared/shared:/app/shared
             - ./writer/writer:/app/writer
             - ./writer/tests:/app/tests
+            - ./cli:/app/cli
         depends_on:
             - postgresql
             - redis

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 # helper file to execute all check commands for travis
-# first argument needs to be the name of the module (shared, reader, writer)
 # must not contain conditionals or loops: each line is evaluated as a single command by execute-travis.sh
 
 set -v
 
-black --check --diff --target-version py38 $1 tests
-isort --check-only --diff --recursive $1 tests
-flake8 $1 tests
-# separate mypy commands to avoid duplicate module error
-mypy $1
-mypy tests
+dirs=$(ls -d */)
+
+black --check --diff --target-version py38 $dirs
+isort --check-only --diff --recursive $dirs
+flake8 $dirs
+mypy $dirs
 pytest --cov


### PR DESCRIPTION
(sets up on #21)

First implementation of the example data import. Doesn't get called automatically yet, but is callable from inside the docker container with `python cli/create_initial_data.py`. It should however be possible to just call this script from the entrypoint. If done this way, the services will all be registered, the script is executed and then everything gets shutdown again just to boot again via the flask command. Since the startup is extremely fast, this shouldn't pose a problem, but maybe you've got a better solution.

In https://github.com/OpenSlides/OpenSlides/blob/bc19de95709ea049267ad455aa00686fcc10328d/docs/example-data.json#L2252 the field begins with an underscore, which is forbidden, so as a workaround I simply delete the field.