### PR TITLE
Make redis public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ endif
 # the two available targets without a MODULE:
 
 ifndef MODULE
+
 # execute the target for all modules
 run-cleanup:
 	@$(MAKE) -C shared $@
@@ -88,5 +89,9 @@ run-tests run-travis:
 build-dev:
 	@$(MAKE) -C reader $@
 	@$(MAKE) -C writer $@
+
+run-prod:
+	docker-compose -f dc.prod.yml up -d reader
+	docker-compose -f dc.prod.yml up -d writer
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,6 @@ build-dev:
 	@$(MAKE) -C writer $@
 
 run-prod:
-	docker-compose -f dc.prod.yml up -d reader
-	docker-compose -f dc.prod.yml up -d writer
+	docker-compose -f dc.prod.yml up -d
 
 endif

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,6 @@ build-dev:
 	@$(MAKE) -C writer $@
 
 run-prod:
-	docker-compose -f dc.prod.yml up -d
+	docker-compose -f dc.prod.yml up
 
 endif

--- a/README.md
+++ b/README.md
@@ -1,3 +1,42 @@
 # OpenSlides datastore service
 
-Service for OpenSlides which ...
+Service for OpenSlides which wraps the database. Includes reader and writer functionality. For available methods see [the specs](https://github.com/OpenSlides/OpenSlides/blob/openslides4-dev/docs/interfaces/datastore-service.txt). For an extensive documentation, see TODO.
+
+## Structure
+
+- /reader: the reader module
+- /writer: the writer module
+- /shared: the shared module. Contains classes and constants used by both the reader and the writer
+- /scripts: useful scripts
+- /requirements: the requirements for testing and in general
+
+## Setup
+
+Since reader, writer and shared mostly need the same commands, the main Makefile contains those. Still, most of the commands need to be issued when in the respective subdirectory since the Makefile there sets the right environment variables. Exceptions to this are the following commands, which are available in the main folder:
+
+- `run-cleanup`, `run-tests`, `run-travis`: runs the corresponding command in all three modules
+- `build-dev`: build the dev images for reader and writer (shared has no dev image since it's included in both the reader and the writer)
+- `run-prod`: see below
+
+## Productive start
+
+`run-prod` starts the reader and writer together with postgres and redis so that the datastore can be used in conjunction with other services. By default the writer listens on port 8000 and the reader on 8001, postgres on port 5432 and redis on 6379. Postgres and redis port can be configured via the environment variables `DATASTORE_DATABASE_PORT` and `MESSAGE_BUS_PORT`, reader and writer port in `dc.prod.yml`. If you need other ports or another setup, you can copy this file into your project and adjust it to your needs.
+
+### Curl example
+
+After you started the productive environment, you can issue requests e.g. via curl. First, create a model:
+
+    curl --header "Content-Type: application/json" -d '{"user_id": 1, "information": {}, "locked_fields": {}, "events": [{"type": "create", "fqid": "a/1", "fields": {"f": 1}}]}' http://localhost:8000/internal/datastore/writer/write
+
+Then you can get that model with:
+
+    curl --header "Content-Type: application/json" -d '{"fqid": "a/1"}' http://localhost:8001/internal/datastore/reader/get
+
+All other commands work analogous to this.
+
+## Other commands
+
+- `run-bash`: starts the module's container and enters an interactive bash where you can issue commands inside the container. Useful for development if you need to repeatedly test and clean up.
+- `run-cleanup`: executes `cleanup.sh` which in turn runs `black`, `isort`, `flake8` and `mypy`.
+- `run-tests`: executes `pytest`
+- `run-coverage`: runs tests and creates a coverage report in `htmlcov`. The needed coverage to pass is defined in `.coveragerc`.

--- a/dc.prod.yml
+++ b/dc.prod.yml
@@ -1,0 +1,56 @@
+version: '3'
+services:
+    reader:
+        build:
+            context: "https://github.com/OpenSlides/openslides-datastore-service.git#prod-startup:reader"
+            args:
+                GIT_CHECKOUT: "${OPENSLIDES_DATASTORE_SERVICE_COMMIT_HASH}"
+        image: openslides-datastore-reader
+        ports:
+            - "8001:8001"
+        depends_on:
+            - postgresql
+        environment:
+            - DATASTORE_DATABASE_HOST=postgresql
+            - DATASTORE_DATABASE_USER=openslides
+            - DATASTORE_DATABASE_PASSWORD=openslides
+            - DATASTORE_DATABASE_NAME=openslides
+        networks:
+            - postgresql
+    writer:
+        build:
+            context: "https://github.com/OpenSlides/openslides-datastore-service.git#prod-startup:writer"
+            args:
+                GIT_CHECKOUT: "${OPENSLIDES_DATASTORE_SERVICE_COMMIT_HASH}"
+        image: openslides-datastore-writer
+        ports:
+            - "8000:8000"
+        depends_on:
+            - postgresql
+            - redis
+        environment:
+            - DATASTORE_DATABASE_HOST=postgresql
+            - DATASTORE_DATABASE_USER=openslides
+            - DATASTORE_DATABASE_PASSWORD=openslides
+            - DATASTORE_DATABASE_NAME=openslides
+            - MESSAGE_BUS_HOST=redis
+        networks:
+            - postgresql
+            - redis
+    postgresql:
+        image: sameersbn/postgresql:10
+        labels:
+            org.openslides.role: "postgres"
+        environment:
+            - DB_USER=openslides
+            - DB_PASS=openslides
+            - DB_NAME=openslides
+        networks:
+            - postgresql
+    redis:
+        image: redis:alpine
+        networks:
+            - redis
+networks:
+    postgresql:
+    redis:

--- a/dc.prod.yml
+++ b/dc.prod.yml
@@ -51,6 +51,8 @@ services:
             - postgresql
     redis:
         image: redis:alpine
+        ports:
+            - "6379:6379"
         networks:
             - redis
 networks:

--- a/dc.prod.yml
+++ b/dc.prod.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
     reader:
         build:
+            # TODO: if you read this comment on master, the branch tag needs to be removed
             context: "https://github.com/OpenSlides/openslides-datastore-service.git#prod-startup:reader"
             args:
                 GIT_CHECKOUT: "${OPENSLIDES_DATASTORE_SERVICE_COMMIT_HASH}"
@@ -19,6 +20,7 @@ services:
             - postgresql
     writer:
         build:
+            # TODO: if you read this comment on master, the branch tag needs to be removed
             context: "https://github.com/OpenSlides/openslides-datastore-service.git#prod-startup:writer"
             args:
                 GIT_CHECKOUT: "${OPENSLIDES_DATASTORE_SERVICE_COMMIT_HASH}"

--- a/reader/Dockerfile
+++ b/reader/Dockerfile
@@ -10,14 +10,14 @@ RUN git clone --no-checkout -- $REPOSITORY_URL .
 RUN git checkout $GIT_CHECKOUT
 RUN git pull
 RUN mkdir /app
-RUN mv shared/shared writer/writer writer/entrypoint.sh writer/requirements.txt requirements/requirements-general.txt /app
+RUN mv shared/shared reader/reader reader/entrypoint.sh reader/requirements.txt requirements/requirements-general.txt /app
 
 WORKDIR /app
 RUN rm -rf /tmp
 RUN pip install -U -r requirements-general.txt
 
-EXPOSE 8000
+EXPOSE 8001
 ENV PYTHONPATH /app/
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:8000", "writer.app:application"]
+CMD ["gunicorn", "-w", "1", "-b", "0.0.0.0:8001", "reader.app:application"]

--- a/scripts/make-targets
+++ b/scripts/make-targets
@@ -1,3 +1,3 @@
 MAKE_TARGETS_SHARED=build-tests run-integration-unit-tests run-coverage-integration-unit run-integration-unit-tests-interactive run-cleanup setup-docker-compose run-tests-no-down run-tests run-bash run-tests-interactive run-system-tests run-coverage run-travis-no-down run-travis
-MAKE_TARGETS_MODULES=$(MAKE_TARGETS_SHARED) build-prod
+MAKE_TARGETS_MODULES=$(MAKE_TARGETS_SHARED) build-prod build-dev run-dev
 export

--- a/writer/Dockerfile.test
+++ b/writer/Dockerfile.test
@@ -9,6 +9,8 @@ COPY writer/requirements.txt .
 RUN pip install -U -r requirements-testing.txt
 COPY scripts/ .
 COPY writer/.coveragerc .
+COPY writer/entrypoint.sh .
 ENV PYTHONPATH /app/
 
+ENTRYPOINT ["./entrypoint.sh"]
 CMD ["pytest"]

--- a/writer/entrypoint.sh
+++ b/writer/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export DATASTORE_DATABASE_PORT="${DATASTORE_DATABASE_PORT:-5432}"
+export MESSAGE_BUS_PORT="${DATASTORE_DATABASE_PORT:-6379}"
 
 # TODO: read optional ports from env variables: db_port and redis_port
 wait-for-it --timeout=15 "$DATASTORE_DATABASE_HOST:$DATASTORE_DATABASE_PORT"

--- a/writer/entrypoint.sh
+++ b/writer/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export DATASTORE_DATABASE_PORT="${DATASTORE_DATABASE_PORT:-5432}"
-export MESSAGE_BUS_PORT="${DATASTORE_DATABASE_PORT:-6379}"
+export MESSAGE_BUS_PORT="${MESSAGE_BUS_PORT:-6379}"
 
 # TODO: read optional ports from env variables: db_port and redis_port
 wait-for-it --timeout=15 "$DATASTORE_DATABASE_HOST:$DATASTORE_DATABASE_PORT"


### PR DESCRIPTION
Redis is part of the public interface of the datastore-service. The autoupdate-service has to access is to get the key-updates. Therefore the redis port has to be published.

I also removed the -d flag of docker-compose. This makes it easier to stop the running containers.