### PR TITLE
Fixed update propagation

### DIFF
--- a/shared/shared/postgresql_backend/pg_connection_handler.py
+++ b/shared/shared/postgresql_backend/pg_connection_handler.py
@@ -97,7 +97,6 @@ class PgConnectionHandlerService:
         connection = self.get_connection_with_open_transaction()
         prepared_query = self.prepare_query(query, sql_parameters)
         with connection.cursor() as cursor:
-            # print(cursor.mogrify(prepared_query, arguments))
             cursor.execute(prepared_query, arguments)
             result = cursor.fetchall()
             return result


### PR DESCRIPTION
As mentioned by @ostcar, the writer must propagate the updates onto redis only after the transaction to the read db has been commited.