### PR TITLE
Improve truncate_db performance

### DIFF
--- a/writer/tests/unit/postgresql_backend/test_sql_database_backend_service.py
+++ b/writer/tests/unit/postgresql_backend/test_sql_database_backend_service.py
@@ -497,5 +497,11 @@ class TestReserveNextIds:
 def test_truncate_db(sql_backend, connection):
     connection.execute = ex = MagicMock()
     sql_backend.truncate_db()
-    assert ex.call_count == len(ALL_TABLES)
-    assert all("TRUNCATE" in call.args[0] for call in ex.call_args_list)
+    assert ex.call_count == len(ALL_TABLES) + 3  # account for sequence resets
+    assert all(
+        "DELETE FROM" in call.args[0] for call in ex.call_args_list[: len(ALL_TABLES)]
+    )
+    assert all(
+        "RESTART" in call.args[0]
+        for call in ex.call_args_list[len(ALL_TABLES) + 1 :]  # noqa: E203
+    )

--- a/writer/writer/postgresql_backend/sql_database_backend_service.py
+++ b/writer/writer/postgresql_backend/sql_database_backend_service.py
@@ -308,6 +308,7 @@ class SqlDatabaseBackendService:
 
     def truncate_db(self) -> None:
         for table in ALL_TABLES:
-            self.connection.execute(
-                f"TRUNCATE TABLE {table} RESTART IDENTITY CASCADE", []
-            )
+            self.connection.execute(f"DELETE FROM {table} CASCADE;", [])
+        # restart sequences manually to provide a clean db
+        for seq in ("positions_position", "events_id", "collectionfields_id"):
+            self.connection.execute(f"ALTER SEQUENCE {seq}_seq RESTART WITH 1;", [])


### PR DESCRIPTION
Some data:
TRUNCATE TABLE:
Total: 3.0464930534362793
per call: 0.03046493053436279

DROP TABLE & rebuild from schema:
Total: 6.06488299369812
per call: 0.0606488299369812

DELETE FROM & restart sequences:
Total: 0.34722089767456055
per call: 0.0034722089767456055

maybe that will speed up the backend tests ;)
