### PR TITLE
Added position tests

### DIFF
--- a/tests/writer/system/write/test_write.py
+++ b/tests/writer/system/write/test_write.py
@@ -637,3 +637,89 @@ def test_two_write_requests_with_locked_fields(
     assert_model("a/1", {"f": 1}, 1)
     assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
     assert_no_modified_fields(redis_connection)
+
+
+def test_position_delete_restore(json_client, data, redis_connection, reset_redis_data):
+    create_model(json_client, data, redis_connection, reset_redis_data)
+
+    data["events"][0] = {"type": "delete", "fqid": "a/1"}
+    response = json_client.post(WRITE_URL, data)
+    assert_response_code(response, 201)
+
+    data["events"][0] = {"type": "restore", "fqid": "a/1"}
+    response = json_client.post(WRITE_URL, data)
+    assert_response_code(response, 201)
+
+    connection_handler = injector.get(ConnectionHandler)
+    with connection_handler.get_connection_context():
+        read_db = injector.get(ReadDatabase)
+        read_db_model = read_db.get("a/1")
+
+        assert read_db_model == {"f": 1, "meta_deleted": False, "meta_position": 3}
+
+
+def test_position_delete(json_client, data, redis_connection, reset_redis_data):
+    create_model(json_client, data, redis_connection, reset_redis_data)
+
+    data["events"][0] = {"type": "delete", "fqid": "a/1"}
+    response = json_client.post(WRITE_URL, data)
+    assert_response_code(response, 201)
+
+    connection_handler = injector.get(ConnectionHandler)
+    with connection_handler.get_connection_context():
+        read_db = injector.get(ReadDatabase)
+        read_db_model = read_db.get(
+            "a/1", get_deleted_models=DeletedModelsBehaviour.ONLY_DELETED
+        )
+
+        assert read_db_model == {"f": 1, "meta_deleted": True, "meta_position": 2}
+
+
+def test_position_update(json_client, data, redis_connection, reset_redis_data):
+    create_model(json_client, data, redis_connection, reset_redis_data)
+
+    data["events"][0] = {"type": "update", "fqid": "a/1", "fields": {"f": 2}}
+    response = json_client.post(WRITE_URL, data)
+    assert_response_code(response, 201)
+
+    connection_handler = injector.get(ConnectionHandler)
+    with connection_handler.get_connection_context():
+        read_db = injector.get(ReadDatabase)
+        read_db_model = read_db.get("a/1")
+
+        assert read_db_model == {"f": 2, "meta_deleted": False, "meta_position": 2}
+
+
+def test_position_delete_field(json_client, data, redis_connection, reset_redis_data):
+    create_model(json_client, data, redis_connection, reset_redis_data)
+
+    data["events"][0] = {"type": "update", "fqid": "a/1", "fields": {"f": None}}
+    response = json_client.post(WRITE_URL, data)
+    assert_response_code(response, 201)
+
+    connection_handler = injector.get(ConnectionHandler)
+    with connection_handler.get_connection_context():
+        read_db = injector.get(ReadDatabase)
+        read_db_model = read_db.get("a/1")
+
+        assert read_db_model == {"meta_deleted": False, "meta_position": 2}
+
+
+def test_position_list_update(json_client, data, redis_connection, reset_redis_data):
+    data["events"][0]["fields"]["f"] = []
+    create_model(json_client, data, redis_connection, reset_redis_data)
+
+    data["events"][0] = {
+        "type": "update",
+        "fqid": "a/1",
+        "list_fields": {"add": {"f": [42]}},
+    }
+    response = json_client.post(WRITE_URL, data)
+    assert_response_code(response, 201)
+
+    connection_handler = injector.get(ConnectionHandler)
+    with connection_handler.get_connection_context():
+        read_db = injector.get(ReadDatabase)
+        read_db_model = read_db.get("a/1")
+
+        assert read_db_model == {"f": [42], "meta_deleted": False, "meta_position": 2}


### PR DESCRIPTION
Asserts, that the read DB always have the right values for meta_position (and meta_deleted) after writing to the datastore. There are no bugs, but I think there are bugs in #135, so we can reuse these tests there.