### PR TITLE
Fixed migration bugs

### DIFF
--- a/datastore/migrations/base_migration.py
+++ b/datastore/migrations/base_migration.py
@@ -52,14 +52,10 @@ class BaseMigration:
                 event, old_accessor, new_accessor, position_data
             )
             if translated_events is None:
-                translated_events = [event]  # noop
+                translated_events = [old_event]  # noop
 
-            print("apply to old", old_event.fqid, old_event.get_data())
             old_accessor.apply_event(old_event)
             for translated_event in translated_events:
-                print(
-                    "apply to new", translated_event.fqid, translated_event.get_data()
-                )
                 new_accessor.apply_event(translated_event)
 
             new_events.extend(translated_events)

--- a/datastore/migrations/events.py
+++ b/datastore/migrations/events.py
@@ -57,12 +57,10 @@ class _ModelEvent(BaseEvent):
 
 class CreateEvent(_ModelEvent):
     type = EVENT_TYPES.CREATE
-    pass
 
 
 class UpdateEvent(_ModelEvent):
     type = EVENT_TYPES.UPDATE
-    pass
 
 
 class DeleteFieldsEvent(BaseEvent):

--- a/tests/migrations/system/test_basic_migrate_cases.py
+++ b/tests/migrations/system/test_basic_migrate_cases.py
@@ -23,7 +23,7 @@ def test_no_migrations_to_apply(
 
     i.assert_called()
     assert (
-        "No migrations to apply. The productive database is up to date"
+        "No migrations to apply. The productive database is up to date."
         in i.call_args[0][0]
     )
 
@@ -41,7 +41,30 @@ def test_finalizing_needed(
     migration_handler.migrate()
 
     i.assert_called()
-    assert "No migrations to apply, but finalizing is still needed" in i.call_args[0][0]
+    assert (
+        "No migrations to apply, but finalizing is still needed."
+        in i.call_args_list[1][0][0]
+    )
+    assert "Done. Finalizing is still be needed." in i.call_args_list[2][0][0]
+
+
+def test_finalizing_not_needed(
+    migration_handler,
+    write,
+):
+    write({"type": "create", "fqid": "a/1", "fields": {}})
+
+    migration_handler.register_migrations(get_noop_migration(2))
+    migration_handler.finalize()
+
+    migration_handler.logger.info = i = MagicMock()
+    migration_handler.finalize()
+
+    i.assert_called()
+    assert (
+        "No migrations to apply. The productive database is up to date."
+        in i.call_args[0][0]
+    )
 
 
 def test_invalid_migration_index(

--- a/tests/migrations/system/test_event_overwrite.py
+++ b/tests/migrations/system/test_event_overwrite.py
@@ -132,3 +132,23 @@ def test_less_events(
 
     assert_count("events", 2)
     assert_model("a/1", {"f": 1, "f2": 2, "meta_deleted": False, "meta_position": 2})
+
+
+def test_return_none_with_modifications(
+    migration_handler,
+    assert_count,
+    write,
+    assert_model,
+    read_model,
+):
+    write({"type": "create", "fqid": "a/1", "fields": {"f": 1}})
+    previous_model = read_model("a/1")
+
+    def handler(event):
+        event.data["f2"] = "Hi"
+        return None
+
+    migration_handler.register_migrations(get_lambda_migration(handler))
+    migration_handler.finalize()
+
+    assert_model("a/1", previous_model)


### PR DESCRIPTION
- double calls to finalize was broken
- returning None in the migration class should definitly use the original event even when modification were done