### PR TITLE
Changed initial migration index

### DIFF
--- a/cli/export_data_only.py
+++ b/cli/export_data_only.py
@@ -9,6 +9,7 @@ from datastore.shared.services.environment_service import (
     DATASTORE_DEV_MODE_ENVIRONMENT_VAR,
     EnvironmentService,
 )
+from datastore.shared.util import is_reserved_field
 
 
 def main():
@@ -26,7 +27,7 @@ def main():
     for collection, models in response.items():
         for model in models:
             for field in list(model.keys()):
-                if field.startswith("meta_"):
+                if is_reserved_field(field):
                     del model[field]
 
     response["_migration_index"] = cast(Any, migration_index)

--- a/datastore/shared/postgresql_backend/sql_read_database_backend_service.py
+++ b/datastore/shared/postgresql_backend/sql_read_database_backend_service.py
@@ -122,6 +122,7 @@ class SqlReadDatabaseBackendService:
 
         result = self.connection.query(query, [], [])
         unsorted_data = defaultdict(list)
+
         for row in result:
             collection, id = collection_and_id_from_fqid(row["__fqid__"])
             model = row["data"]
@@ -359,7 +360,7 @@ class SqlReadDatabaseBackendService:
                         + f"different to {max_migration_index}"
                     )
             else:
-                max_migration_index = 1
+                max_migration_index = -1
             self.current_migration_index = max_migration_index
         return self.current_migration_index
 

--- a/tests/migrations/system/conftest.py
+++ b/tests/migrations/system/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from datastore.migrations import MigrationHandler, setup as migration_setup
@@ -145,3 +147,19 @@ def assert_finalized(assert_count):
         assert_count("migration_positions", 0)
 
     return _assert_finalized
+
+
+@pytest.fixture()
+def set_migration_index_to_1(migration_handler):
+    def _set_migration_index_to_1():
+        previous_logger = migration_handler.logger.info
+        migration_handler.logger.info = i = MagicMock()
+        migration_handler.migrate()  # set target migration index to 1
+        i.assert_called()
+        assert (
+            "The datastore has a migration index of -1. Set the migration index to 1."
+            in i.call_args.args[0]
+        )
+        migration_handler.logger.info = previous_logger
+
+    yield _set_migration_index_to_1

--- a/tests/migrations/system/test_check_latest.py
+++ b/tests/migrations/system/test_check_latest.py
@@ -8,13 +8,8 @@ def test_set_latest_migrate(
 ):
     write({"type": "create", "fqid": "a/1", "fields": {}})
     write({"type": "create", "fqid": "a/2", "fields": {}})
-    with connection_handler.get_connection_context():
-        connection_handler.execute(
-            "update positions set migration_index=%s",
-            [-1],
-        )
-    migration_handler.run_migrations = rm = MagicMock()
 
+    migration_handler.run_migrations = rm = MagicMock()
     migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.migrate()
 
@@ -28,13 +23,8 @@ def test_migration_index_too_high_finalize(
 ):
     write({"type": "create", "fqid": "a/1", "fields": {}})
     write({"type": "create", "fqid": "a/2", "fields": {}})
-    with connection_handler.get_connection_context():
-        connection_handler.execute(
-            "update positions set migration_index=%s",
-            [-1],
-        )
-    migration_handler.run_migrations = rm = MagicMock()
 
+    migration_handler.run_migrations = rm = MagicMock()
     migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.finalize()
 

--- a/tests/migrations/system/test_finalize_noop_migration.py
+++ b/tests/migrations/system/test_finalize_noop_migration.py
@@ -12,15 +12,18 @@ class Base:
         self,
         migration_handler,
         write,
+        set_migration_index_to_1,
         read_model,
         assert_model,
         query_single_value,
         assert_finalized,
     ):
         def _readback(*data):
-            migration_handler.register_migrations(get_noop_migration(2))
             self.write_data(write, *data)
+            set_migration_index_to_1()
             previous_model = read_model("a/1")
+
+            migration_handler.register_migrations(get_noop_migration(2))
             migration_handler.finalize()
 
             assert_model("a/1", previous_model)

--- a/tests/migrations/system/test_migration_index_too_high.py
+++ b/tests/migrations/system/test_migration_index_too_high.py
@@ -7,8 +7,11 @@ from datastore.migrations import MismatchingMigrationIndicesException
 from ..util import get_noop_migration
 
 
-def test_migration_index_too_high_migrate(migration_handler, write, query_single_value):
+def test_migration_index_too_high_migrate(
+    migration_handler, write, set_migration_index_to_1, query_single_value
+):
     write({"type": "create", "fqid": "a/1", "fields": {}})
+    set_migration_index_to_1()
     migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.migrate()
 
@@ -25,9 +28,10 @@ def test_migration_index_too_high_migrate(migration_handler, write, query_single
 
 
 def test_migration_index_too_high_finalize(
-    migration_handler, write, query_single_value
+    migration_handler, write, set_migration_index_to_1, query_single_value
 ):
     write({"type": "create", "fqid": "a/1", "fields": {}})
+    set_migration_index_to_1()
     migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.finalize()
 
@@ -43,8 +47,11 @@ def test_migration_index_too_high_finalize(
     rm.assert_not_called()
 
 
-def test_migration_index_too_high_reset(migration_handler, write, query_single_value):
+def test_migration_index_too_high_reset(
+    migration_handler, write, set_migration_index_to_1, query_single_value
+):
     write({"type": "create", "fqid": "a/1", "fields": {}})
+    set_migration_index_to_1()
     migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.finalize()
 

--- a/tests/migrations/system/test_migration_keyframes.py
+++ b/tests/migrations/system/test_migration_keyframes.py
@@ -19,9 +19,10 @@ class BaseTest:
         raise NotImplementedError()
 
     @pytest.fixture()
-    def write_data(self, write):
+    def write_data(self, write, set_migration_index_to_1):
         def _write_data(*data):
             self._write(write, *data)
+            set_migration_index_to_1()
 
         yield _write_data
 

--- a/tests/migrations/system/test_multiple_migrations_and_positions.py
+++ b/tests/migrations/system/test_multiple_migrations_and_positions.py
@@ -6,11 +6,13 @@ from ..util import get_lambda_migration, get_noop_migration
 
 
 def test_multiple_migrations_together(
-    migration_handler, write, read_model, assert_model, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    assert_finalized,
 ):
-    migration_handler.register_migrations(
-        get_noop_migration(2), get_noop_migration(3), get_noop_migration(4)
-    )
     write(
         {"type": "create", "fqid": "a/1", "fields": {"f": 1, "g": 1, "h": [], "i": [1]}}
     )
@@ -24,7 +26,12 @@ def test_multiple_migrations_together(
     )
     write({"type": "delete", "fqid": "a/1"})
     write({"type": "restore", "fqid": "a/1"})
+    set_migration_index_to_1()
     previous_model = read_model("a/1")
+
+    migration_handler.register_migrations(
+        get_noop_migration(2), get_noop_migration(3), get_noop_migration(4)
+    )
     migration_handler.finalize()
 
     assert_model("a/1", previous_model)
@@ -32,10 +39,16 @@ def test_multiple_migrations_together(
 
 
 def test_second_position_access_old_and_new_data(
-    migration_handler, write, read_model, assert_model, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    assert_finalized,
 ):
     write({"type": "create", "fqid": "a/1", "fields": {"f": 1}})
     write({"type": "create", "fqid": "trigger/1", "fields": {}})
+    set_migration_index_to_1()
 
     class TestMigration(BaseMigration):
         target_migration_index = 2
@@ -63,8 +76,16 @@ def test_second_position_access_old_and_new_data(
 
 
 def test_second_migration_gets_events_from_first(
-    migration_handler, write, read_model, assert_model, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    assert_finalized,
 ):
+    write({"type": "create", "fqid": "a/1", "fields": {}})
+    set_migration_index_to_1()
+
     first = get_lambda_migration(lambda _: [CreateEvent("a/2", {})])
 
     captured_event = (
@@ -78,7 +99,6 @@ def test_second_migration_gets_events_from_first(
     second = get_lambda_migration(capture_handler, target_migration_index=3)
 
     migration_handler.register_migrations(first, second)
-    write({"type": "create", "fqid": "a/1", "fields": {}})
     migration_handler.finalize()
 
     assert_finalized()
@@ -86,22 +106,29 @@ def test_second_migration_gets_events_from_first(
     assert captured_event["event"].fqid == "a/2"
 
 
-def test_amount_events(migration_handler, write, assert_count):
-    migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
+def test_amount_events(
+    migration_handler, write, set_migration_index_to_1, assert_count
+):
     write(
         {"type": "create", "fqid": "a/1", "fields": {"f": 1, "g": 1, "h": [], "i": [1]}}
     )
+    set_migration_index_to_1()
+
+    migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.finalize()
+
     assert_count("events", 1)
     assert_count("migration_events", 0)
 
 
 def test_migrate_finalize(
-    migration_handler, write, read_model, assert_model, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    assert_finalized,
 ):
-    migration_handler.register_migrations(
-        get_noop_migration(2), get_noop_migration(3), get_noop_migration(4)
-    )
     write(
         {"type": "create", "fqid": "a/1", "fields": {"f": 1, "g": 1, "h": [], "i": [1]}}
     )
@@ -115,7 +142,12 @@ def test_migrate_finalize(
     )
     write({"type": "delete", "fqid": "a/1"})
     write({"type": "restore", "fqid": "a/1"})
+    set_migration_index_to_1()
     previous_model = read_model("a/1")
+
+    migration_handler.register_migrations(
+        get_noop_migration(2), get_noop_migration(3), get_noop_migration(4)
+    )
     migration_handler.migrate()
     migration_handler.finalize()
 
@@ -124,9 +156,13 @@ def test_migrate_finalize(
 
 
 def test_multiple_migrations_following(
-    migration_handler, write, read_model, assert_model, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    assert_finalized,
 ):
-    migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     write(
         {"type": "create", "fqid": "a/1", "fields": {"f": 1, "g": 1, "h": [], "i": [1]}}
     )
@@ -140,8 +176,10 @@ def test_multiple_migrations_following(
     )
     write({"type": "delete", "fqid": "a/1"})
     write({"type": "restore", "fqid": "a/1"})
+    set_migration_index_to_1()
     previous_model = read_model("a/1")
 
+    migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))
     migration_handler.finalize()
 
     assert_model("a/1", previous_model)
@@ -161,14 +199,20 @@ def test_multiple_migrations_following(
 
 
 def test_multiple_migrations_one_finalizing(
-    migration_handler, write, read_model, assert_model, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    assert_finalized,
 ):
     """This tests the deletion of the keyframe in move_to_next_position"""
-    migration_handler.register_migrations(get_noop_migration(2))
     write({"type": "create", "fqid": "a/1", "fields": {"f": 1}})
     write({"type": "update", "fqid": "a/1", "fields": {"f": 2}})
+    set_migration_index_to_1()
     previous_model = read_model("a/1")
 
+    migration_handler.register_migrations(get_noop_migration(2))
     migration_handler.migrate()
     migration_handler.migrations_by_target_migration_index = {}
     migration_handler.register_migrations(get_noop_migration(2), get_noop_migration(3))

--- a/tests/migrations/system/test_premade_migration_classes.py
+++ b/tests/migrations/system/test_premade_migration_classes.py
@@ -2,7 +2,12 @@ from datastore.migrations import AddFieldMigration, RenameFieldMigration
 
 
 def test_rename_field(
-    migration_handler, write, assert_model, query_single_value, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_model,
+    query_single_value,
+    assert_finalized,
 ):
     """f -> f_new"""
     write({"type": "create", "fqid": "a/1", "fields": {"f": [1]}})
@@ -11,6 +16,7 @@ def test_rename_field(
     write({"type": "update", "fqid": "a/1", "list_fields": {"add": {"f": [3]}}})
     write({"type": "update", "fqid": "a/1", "fields": {"f": None}})
     write({"type": "update", "fqid": "a/1", "fields": {"f": "Hello"}})
+    set_migration_index_to_1()
 
     class RenameField(RenameFieldMigration):
         target_migration_index = 2
@@ -41,11 +47,17 @@ def test_rename_field(
 
 
 def test_add_field_with_default(
-    migration_handler, write, assert_model, query_single_value, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_model,
+    query_single_value,
+    assert_finalized,
 ):
     write({"type": "create", "fqid": "a/1", "fields": {"f": 3}})
     write({"type": "create", "fqid": "b/1", "fields": {"x": 42}})
     write({"type": "update", "fqid": "a/1", "fields": {"f": 5, "g": 127}})
+    set_migration_index_to_1()
 
     class AddField(AddFieldMigration):
         target_migration_index = 2

--- a/tests/migrations/system/test_reset_migration.py
+++ b/tests/migrations/system/test_reset_migration.py
@@ -3,9 +3,12 @@ from datastore.migrations import CreateEvent
 from ..util import get_lambda_migration, get_noop_migration
 
 
-def test_no_migrations(migration_handler, write, assert_count):
+def test_no_migrations(
+    migration_handler, write, set_migration_index_to_1, assert_count
+):
     write({"type": "create", "fqid": "a/1", "fields": {}})
     write({"type": "create", "fqid": "a/2", "fields": {}})
+    set_migration_index_to_1()
 
     assert_count("migration_keyframes", 0)
     assert_count("migration_positions", 0)
@@ -19,9 +22,12 @@ def test_no_migrations(migration_handler, write, assert_count):
     assert_count("migration_events", 0)
 
 
-def test_ongoing_migrations(migration_handler, write, assert_count):
+def test_ongoing_migrations(
+    migration_handler, write, set_migration_index_to_1, assert_count
+):
     write({"type": "create", "fqid": "a/1", "fields": {}})
     write({"type": "create", "fqid": "a/2", "fields": {}})
+    set_migration_index_to_1()
 
     assert_count("migration_keyframes", 0)
     assert_count("migration_positions", 0)
@@ -42,9 +48,15 @@ def test_ongoing_migrations(migration_handler, write, assert_count):
 
 
 def test_actual_migration(
-    migration_handler, write, read_model, assert_model, query_single_value
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    read_model,
+    assert_model,
+    query_single_value,
 ):
     write({"type": "create", "fqid": "a/1", "fields": {}})
+    set_migration_index_to_1()
     previous_model = read_model("a/1")
 
     event = CreateEvent("a/2", {})

--- a/tests/migrations/system/test_sample_migrations.py
+++ b/tests/migrations/system/test_sample_migrations.py
@@ -19,6 +19,7 @@ from datastore.shared.util import (
 def test_move_id(
     migration_handler,
     write,
+    set_migration_index_to_1,
     assert_model,
     exists_model,
     query_single_value,
@@ -38,6 +39,7 @@ def test_move_id(
     write({"type": "update", "fqid": "a/1", "fields": {"f": None}})
     write({"type": "delete", "fqid": "a/1"})
     write({"type": "restore", "fqid": "a/1"})
+    set_migration_index_to_1()
 
     class MoveId(BaseMigration):
         target_migration_index = 2
@@ -75,7 +77,12 @@ def test_move_id(
 
 
 def test_remove_field(
-    migration_handler, write, assert_model, query_single_value, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_model,
+    query_single_value,
+    assert_finalized,
 ):
     """remove f"""
     write({"type": "create", "fqid": "a/1", "fields": {"f": [1]}})
@@ -83,6 +90,7 @@ def test_remove_field(
     write({"type": "update", "fqid": "a/1", "list_fields": {"add": {"f": [3]}}})
     write({"type": "update", "fqid": "a/1", "fields": {"f": None}})
     write({"type": "update", "fqid": "a/1", "fields": {"f": "Hello"}})
+    set_migration_index_to_1()
 
     class RemoveField(BaseMigration):
         target_migration_index = 2
@@ -116,10 +124,16 @@ def test_remove_field(
 
 
 def test_add_required_field_based_on_migrated_data(
-    migration_handler, write, assert_model, query_single_value, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_model,
+    query_single_value,
+    assert_finalized,
 ):
     """First, rename f->f_new. Second migration adds `g`, which is f_new*2"""
     write({"type": "create", "fqid": "a/1", "fields": {"f": 3}})
+    set_migration_index_to_1()
 
     class RenameField(RenameFieldMigration):
         target_migration_index = 2
@@ -146,11 +160,17 @@ def test_add_required_field_based_on_migrated_data(
 
 
 def test_create_additional_model(
-    migration_handler, write, assert_model, query_single_value, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_model,
+    query_single_value,
+    assert_finalized,
 ):
     """Also a setup-for-tests scenario here."""
     write({"type": "create", "fqid": "config/1", "fields": {"create_b": True}})
     write({"type": "create", "fqid": "a/1", "fields": {}})
+    set_migration_index_to_1()
 
     class CreateModel(BaseMigration):
         target_migration_index = 2
@@ -173,7 +193,12 @@ def test_create_additional_model(
 
 
 def test_access_field_after_rename(
-    migration_handler, write, assert_model, query_single_value, assert_finalized
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_model,
+    query_single_value,
+    assert_finalized,
 ):
     """First rename f->f_new. In a second migration access both fields via both accessors"""
     write({"type": "create", "fqid": "a/1", "fields": {"f": [1]}})
@@ -182,6 +207,7 @@ def test_access_field_after_rename(
     write({"type": "update", "fqid": "a/1", "fields": {"f": "Hello"}})
     write({"type": "delete", "fqid": "a/1"})
     write({"type": "restore", "fqid": "a/1"})
+    set_migration_index_to_1()
 
     class RenameField(RenameFieldMigration):
         target_migration_index = 2

--- a/tests/shared/unit/postgresql_backend/test_sql_read_database_backend_service.py
+++ b/tests/shared/unit/postgresql_backend/test_sql_read_database_backend_service.py
@@ -358,10 +358,10 @@ def test_get_current_migration_index_cached(
     read_database: ReadDatabase, connection: ConnectionHandler
 ):
     connection.query_single_value = qsv = MagicMock(return_value=None)
-    assert read_database.get_current_migration_index() == 1
+    assert read_database.get_current_migration_index() == -1
     qsv.assert_called_once()
 
     # second try; now it should be cached
     connection.query_single_value = qsv = MagicMock(return_value=None)
-    assert read_database.get_current_migration_index() == 1
+    assert read_database.get_current_migration_index() == -1
     qsv.assert_not_called()

--- a/tests/writer/system/write/test_migration_index.py
+++ b/tests/writer/system/write/test_migration_index.py
@@ -34,7 +34,7 @@ def test_initial_migration_index(
 
     db_cur.execute("select migration_index from positions where position=%s", [1])
     migration_index = db_cur.fetchone()[0]
-    assert migration_index == 1
+    assert migration_index == -1
 
 
 def test_use_current_migration_index(
@@ -106,4 +106,4 @@ def test_send_migration_index_not_empty(
 
     db_cur.execute("select migration_index from positions where position=%s", [1])
     migration_index = db_cur.fetchone()[0]
-    assert migration_index == 1
+    assert migration_index == -1


### PR DESCRIPTION
Use -1 as the default migration index (previously it was 1 if not the
import tools were used).

Supersedes #145