### PR TITLE
Performance improvements for write

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Start containers
-      run: make run-dev
+      run: make run-dev-standalone
     
     - name: Execute tests
       run: make run-full-system-tests-check

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 build-dev:
 	docker build -t openslides-datastore-$(MODULE)-dev -f Dockerfile.dev $(build_args) .
 
-run-dev: | build-dev
+run-dev-standalone: | build-dev
 	docker-compose -f dc.dev.yml up -d $(MODULE)
 
 run-dev-verbose: | build-dev
@@ -44,7 +44,7 @@ run-tests: | run-tests-no-down
 	@$(MAKE) run-dev
 	@$(MAKE) run-full-system-tests
 
-run-tests-interactive run-bash: | setup-docker-compose
+run-dev run-bash: | setup-docker-compose
 	docker-compose -f dc.test.yml exec -u $$(id -u $${USER}):$$(id -g $${USER}) datastore ./entrypoint.sh bash
 
 run-system-tests: | setup-docker-compose
@@ -101,7 +101,7 @@ run:
 run-verbose:
 	docker-compose up
 
-run-dev: | build-dev
+run-dev-standalone: | build-dev
 	docker-compose -f dc.dev.yml up -d
 
 run-dev-verbose: | build-dev

--- a/datastore/migrations/core/events.py
+++ b/datastore/migrations/core/events.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List
 
-from datastore.shared.postgresql_backend import EVENT_TYPES, ListUpdatesDict
+from datastore.shared.postgresql_backend import EVENT_TYPE, ListUpdatesDict
 from datastore.shared.typing import Field, Fqid, Model
 from datastore.shared.util import (
     InvalidKeyFormat,
@@ -56,15 +56,15 @@ class _ModelEvent(BaseEvent):
 
 
 class CreateEvent(_ModelEvent):
-    type = EVENT_TYPES.CREATE
+    type = EVENT_TYPE.CREATE
 
 
 class UpdateEvent(_ModelEvent):
-    type = EVENT_TYPES.UPDATE
+    type = EVENT_TYPE.UPDATE
 
 
 class DeleteFieldsEvent(BaseEvent):
-    type = EVENT_TYPES.DELETE_FIELDS
+    type = EVENT_TYPE.DELETE_FIELDS
 
     def __init__(self, fqid: Fqid, data: List[Field]) -> None:
         super().__init__(fqid, data)
@@ -77,7 +77,7 @@ class DeleteFieldsEvent(BaseEvent):
 
 
 class ListUpdateEvent(BaseEvent):
-    type = EVENT_TYPES.LIST_FIELDS
+    type = EVENT_TYPE.LIST_FIELDS
 
     def __init__(self, fqid: Fqid, data: Dict[str, ListUpdatesDict]) -> None:
         self.add = data.pop("add", {})
@@ -98,26 +98,26 @@ class ListUpdateEvent(BaseEvent):
 
 
 class DeleteEvent(BaseEvent):
-    type = EVENT_TYPES.DELETE
+    type = EVENT_TYPE.DELETE
 
     def __init__(self, fqid: Fqid, data: Any = None) -> None:
         super().__init__(fqid, None)
 
 
 class RestoreEvent(BaseEvent):
-    type = EVENT_TYPES.RESTORE
+    type = EVENT_TYPE.RESTORE
 
     def __init__(self, fqid: Fqid, data: Any = None) -> None:
         super().__init__(fqid, None)
 
 
 EVENT_TYPE_TRANSLATION = {
-    EVENT_TYPES.CREATE: CreateEvent,
-    EVENT_TYPES.UPDATE: UpdateEvent,
-    EVENT_TYPES.DELETE_FIELDS: DeleteFieldsEvent,
-    EVENT_TYPES.LIST_FIELDS: ListUpdateEvent,
-    EVENT_TYPES.DELETE: DeleteEvent,
-    EVENT_TYPES.RESTORE: RestoreEvent,
+    EVENT_TYPE.CREATE: CreateEvent,
+    EVENT_TYPE.UPDATE: UpdateEvent,
+    EVENT_TYPE.DELETE_FIELDS: DeleteFieldsEvent,
+    EVENT_TYPE.LIST_FIELDS: ListUpdateEvent,
+    EVENT_TYPE.DELETE: DeleteEvent,
+    EVENT_TYPE.RESTORE: RestoreEvent,
 }
 
 

--- a/datastore/migrations/core/migration_handler.py
+++ b/datastore/migrations/core/migration_handler.py
@@ -153,6 +153,7 @@ class MigrationHandlerImplementation:
     def finalize(self) -> None:
         self.logger.info("Finalize migrations.")
         if self.run_checks():
+            self.delete_collectionfield_aux_tables()
             return
         if not self.run_migrations():
             return

--- a/datastore/shared/postgresql_backend/__init__.py
+++ b/datastore/shared/postgresql_backend/__init__.py
@@ -1,7 +1,7 @@
 from .apply_list_updates import ListUpdatesDict, apply_fields  # noqa
 from .connection_handler import ConnectionHandler, DatabaseError  # noqa
 from .pg_connection_handler import retry_on_db_failure  # noqa
-from .sql_event_types import EVENT_TYPES  # noqa
+from .sql_event_types import EVENT_TYPE  # noqa
 from .sql_query_helper import SqlQueryHelper
 
 

--- a/datastore/shared/postgresql_backend/connection_handler.py
+++ b/datastore/shared/postgresql_backend/connection_handler.py
@@ -20,10 +20,10 @@ class ConnectionHandler(Protocol):
         specific json representation
         """
 
-    def execute(self, query, arguments, sql_parameters=[]):
+    def execute(self, query, arguments, sql_parameters=[], use_execute_values=False):
         """Executes the query."""
 
-    def query(self, query, arguments, sql_parameters=[]):
+    def query(self, query, arguments, sql_parameters=[], use_execute_values=False):
         """
         Executes the query. returns all results in a matrix-fashion:
         Each row is a result, and each column one value of one result.
@@ -39,7 +39,9 @@ class ConnectionHandler(Protocol):
         row, that contains null.
         """
 
-    def query_list_of_single_values(self, query, arguments, sql_parameters=[]):
+    def query_list_of_single_values(
+        self, query, arguments, sql_parameters=[], use_execute_values=False
+    ):
         """
         Returns a list of values of each row. It is expected that each
         row returns exactly one value. An empty list will be returned if

--- a/datastore/shared/postgresql_backend/pg_connection_handler.py
+++ b/datastore/shared/postgresql_backend/pg_connection_handler.py
@@ -55,6 +55,9 @@ class DATABASE_ENVIRONMENT_VARIABLES:
     PASSWORD_FILE = "DATASTORE_DATABASE_PASSWORD_FILE"
 
 
+EXECUTE_VALUES_PAGE_SIZE = int(1e7)
+
+
 class ConnectionContext:
     def __init__(self, connection_handler):
         self.connection_handler = connection_handler
@@ -166,7 +169,12 @@ class PgConnectionHandlerService:
         prepared_query = self.prepare_query(query, sql_parameters)
         with self.get_current_connection().cursor() as cursor:
             if use_execute_values:
-                execute_values(cursor, prepared_query, arguments)
+                execute_values(
+                    cursor,
+                    prepared_query,
+                    arguments,
+                    page_size=EXECUTE_VALUES_PAGE_SIZE,
+                )
             else:
                 cursor.execute(prepared_query, arguments)
 
@@ -174,7 +182,13 @@ class PgConnectionHandlerService:
         prepared_query = self.prepare_query(query, sql_parameters)
         with self.get_current_connection().cursor() as cursor:
             if use_execute_values:
-                result = execute_values(cursor, prepared_query, arguments, fetch=True)
+                result = execute_values(
+                    cursor,
+                    prepared_query,
+                    arguments,
+                    page_size=EXECUTE_VALUES_PAGE_SIZE,
+                    fetch=True,
+                )
             else:
                 cursor.execute(prepared_query, arguments)
                 result = cursor.fetchall()

--- a/datastore/shared/postgresql_backend/sql_event_types.py
+++ b/datastore/shared/postgresql_backend/sql_event_types.py
@@ -1,4 +1,7 @@
-class EVENT_TYPES:
+from enum import Enum
+
+
+class EVENT_TYPE(str, Enum):
     CREATE = "create"
     UPDATE = "update"
     DELETE = "delete"

--- a/datastore/shared/services/environment_service.py
+++ b/datastore/shared/services/environment_service.py
@@ -8,6 +8,11 @@ DATASTORE_DEV_MODE_ENVIRONMENT_VAR = "OPENSLIDES_DEVELOPMENT"
 DEV_SECRET = "openslides"
 
 
+def is_truthy(value: str) -> bool:
+    truthy = ("1", "on", "true")
+    return value.lower() in truthy
+
+
 class EnvironmentVariableMissing(Exception):
     def __init__(self, name: str):
         self.name = name
@@ -37,7 +42,7 @@ class EnvironmentService:
 
     def is_dev_mode(self) -> bool:
         value = self.try_get(DATASTORE_DEV_MODE_ENVIRONMENT_VAR)
-        return value is not None and value.lower() in ("1", "on", "true")
+        return value is not None and is_truthy(value)
 
     def get_from_file(self, name: str, use_default_secret: bool = True) -> str:
         if self.is_dev_mode() and use_default_secret:

--- a/datastore/shared/services/read_database.py
+++ b/datastore/shared/services/read_database.py
@@ -1,5 +1,14 @@
 from dataclasses import dataclass
-from typing import Any, ContextManager, Dict, List, Optional, Protocol, TypedDict
+from typing import (
+    Any,
+    ContextManager,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    TypedDict,
+)
 
 from datastore.shared.di import service_interface
 from datastore.shared.typing import JSON, Collection, Field, Fqid, Id, Model, Position
@@ -59,7 +68,7 @@ class ReadDatabase(Protocol):
 
     def get_many(
         self,
-        fqids: List[Fqid],
+        fqids: Iterable[Fqid],
         mapped_fields_per_fqid: Dict[Fqid, List[Field]] = {},
         get_deleted_models: DeletedModelsBehaviour = DeletedModelsBehaviour.NO_DELETED,
     ) -> Dict[Fqid, Model]:

--- a/datastore/writer/postgresql_backend/sql_database_backend_service.py
+++ b/datastore/writer/postgresql_backend/sql_database_backend_service.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from copy import deepcopy
 from textwrap import dedent
 from typing import ContextManager, Dict, Iterable, List, Tuple
 
@@ -93,7 +92,7 @@ class SqlDatabaseBackendService:
                 fqid = db_event.fqid
                 collection, id = collection_and_id_from_fqid(fqid)
 
-                # create event data now, before further changes to the event
+                # create event data
                 events_data.append(
                     (
                         position,
@@ -266,7 +265,7 @@ class SqlDatabaseBackendService:
         self.connection.execute(statement, arguments, use_execute_values=True)
 
     def json(self, data):
-        return self.connection.to_json(deepcopy(data))
+        return self.connection.to_json(data)
 
     def reserve_next_ids(self, collection: str, amount: int) -> List[Id]:
         if amount <= 0:

--- a/datastore/writer/postgresql_backend/sql_database_backend_service.py
+++ b/datastore/writer/postgresql_backend/sql_database_backend_service.py
@@ -1,27 +1,24 @@
 from collections import defaultdict
+from copy import deepcopy
 from textwrap import dedent
-from typing import Any, ContextManager, Dict, List, Tuple
+from typing import ContextManager, Dict, Iterable, List, Tuple
 
 from datastore.shared.di import service_as_singleton
 from datastore.shared.postgresql_backend import (
     ALL_TABLES,
-    EVENT_TYPES,
+    EVENT_TYPE,
     ConnectionHandler,
 )
 from datastore.shared.services import ReadDatabase
-from datastore.shared.typing import JSON, Field, Fqid, Id, Model, Position
+from datastore.shared.typing import JSON, Collection, Field, Fqid, Id, Model, Position
 from datastore.shared.util import (
     META_DELETED,
     META_POSITION,
     BadCodingError,
     DeletedModelsBehaviour,
     InvalidFormat,
-    ModelDoesNotExist,
-    ModelExists,
-    ModelNotDeleted,
-    collection_from_fqid,
+    collection_and_id_from_fqid,
     collectionfield_from_fqid_and_field,
-    id_from_fqid,
     logger,
 )
 from datastore.writer.core import BaseRequestEvent
@@ -48,8 +45,7 @@ FQID_MAX_LEN = 48  # collection + id
 COLLECTIONFIELD_MAX_LEN = 239  # collection + field
 
 
-# TODO: Make this a factory, so position and event_weight
-# must not be passed through all calls.
+EventData = Tuple[Position, Fqid, EVENT_TYPE, JSON, int]
 
 
 @service_as_singleton
@@ -73,18 +69,69 @@ class SqlDatabaseBackendService:
             raise BadCodingError()
 
         position = self.create_position(migration_index, information, user_id)
+
+        # save all changes to all models to send them over redis
         modified_models: Dict[Fqid, Dict[Field, JSON]] = defaultdict(dict)
-        weight = 1
+        # save max id per collection to update the id_sequences if needed
+        max_id_per_collection: Dict[Collection, int] = {}
+        # save the raw data of the events to be inserted
+        events_data: List[EventData] = []
+        # save all event indices which modified collection fields to connect them later
+        event_indices_per_modified_collectionfield: Dict[str, List[int]] = defaultdict(
+            list
+        )
+
+        # prefetch all needed data to reduce the amount of queries
+        models = self.get_models_from_events(events)
+
+        weight = 0
         for event in events:
-            db_events = self.event_translator.translate(event)
+            # the event translator also handles the validation of the event preconditions
+            db_events = self.event_translator.translate(event, models)
             for db_event in db_events:
-                if len(event.fqid) > FQID_MAX_LEN:
-                    raise InvalidFormat(
-                        f"fqid {db_event.fqid} is too long (max: {FQID_MAX_LEN})"
-                    )
-                self.insert_event(db_event, position, weight)
-                modified_models[db_event.fqid].update(db_event.get_modified_fields())
                 weight += 1
+                fqid = db_event.fqid
+                collection, id = collection_and_id_from_fqid(fqid)
+
+                # create event data now, before further changes to the event
+                events_data.append(
+                    (
+                        position,
+                        fqid,
+                        db_event.event_type,
+                        self.json(db_event.get_event_data()),
+                        weight,
+                    )
+                )
+
+                for collectionfield in self.get_modified_collectionfields_from_event(
+                    db_event
+                ):
+                    # weight is 1-indexed while the ids are 0-indexed
+                    event_indices_per_modified_collectionfield[collectionfield].append(
+                        weight - 1
+                    )
+
+                if isinstance(db_event, DbCreateEvent):
+                    max_id_per_collection[collection] = max(
+                        max_id_per_collection.get(collection, 0), id + 1
+                    )
+                self.apply_event_to_models(db_event, models, position)
+                modified_models[fqid].update(db_event.get_modified_fields())
+
+        self.update_id_sequences(max_id_per_collection)
+        self.write_model_updates(models)
+        event_ids = self.write_events(events_data)
+
+        # update collectionfield tables
+        collectionfield_ids = self.insert_modified_collectionfields_into_db(
+            event_indices_per_modified_collectionfield.keys(), position
+        )
+        self.connect_events_and_collection_fields(
+            event_ids,
+            collectionfield_ids,
+            event_indices_per_modified_collectionfield.values(),
+        )
         return position, modified_models
 
     def create_position(
@@ -93,233 +140,76 @@ class SqlDatabaseBackendService:
         statement = dedent(
             """\
             insert into positions (timestamp, migration_index, user_id, information)
-            values (current_timestamp, %s, %s, %s)"""
+            values (current_timestamp, %s, %s, %s) returning position"""
         )
         arguments = [migration_index, user_id, self.json(information)]
-        self.connection.execute(statement, arguments)
-        query = "select max(position) from positions"
-        position = self.connection.query_single_value(query, [])
+        position = self.connection.query_single_value(statement, arguments)
         logger.info(f"Created position {position}")
         return position
 
-    def insert_event(
-        self, event: BaseDbEvent, position: Position, event_weight: int
+    def get_models_from_events(
+        self, events: List[BaseRequestEvent]
+    ) -> Dict[Fqid, Model]:
+        fqids = set()
+        for event in events:
+            if len(event.fqid) > FQID_MAX_LEN:
+                raise InvalidFormat(
+                    f"fqid {event.fqid} is too long (max: {FQID_MAX_LEN})"
+                )
+
+            fqids.add(event.fqid)
+        return self.read_database.get_many(
+            fqids, get_deleted_models=DeletedModelsBehaviour.ALL_MODELS
+        )
+
+    def apply_event_to_models(
+        self, event: BaseDbEvent, models: Dict[Fqid, Model], position: Position
     ) -> None:
         if isinstance(event, DbCreateEvent):
-            self.insert_create_event(event, position, event_weight)
-        elif isinstance(event, DbUpdateEvent):
-            self.insert_update_event(event, position, event_weight)
-        elif isinstance(event, DbListUpdateEvent):
-            self.insert_list_update_event(event, position, event_weight)
+            models[event.fqid] = {**event.field_data, META_DELETED: False}
+        elif isinstance(event, (DbUpdateEvent, DbListUpdateEvent)):
+            models[event.fqid].update(event.get_modified_fields())
         elif isinstance(event, DbDeleteFieldsEvent):
-            self.insert_delete_fields_event(event, position, event_weight)
-        elif isinstance(event, DbDeleteEvent):
-            self.insert_delete_event(event, position, event_weight)
-        elif isinstance(event, DbRestoreEvent):
-            self.insert_restore_event(event, position, event_weight)
+            for field in event.fields:
+                if field in models[event.fqid]:
+                    del models[event.fqid][field]
+        elif isinstance(event, (DbDeleteEvent, DbRestoreEvent)):
+            models[event.fqid][META_DELETED] = isinstance(event, DbDeleteEvent)
         else:
             raise BadCodingError()
+        models[event.fqid][META_POSITION] = position
 
-    def insert_db_event(
-        self, event: BaseDbEvent, arguments: List[Any], position: Position
-    ) -> None:
-        """
-        Adds a new event to the events table. Makes sure, that the `collectionfields`
-        and `events_to_collectionfields` are updated.
-        """
-        event_id = self.connection.query_single_value(
-            dedent(
-                """\
-                insert into events (position, fqid, type, data, weight)
-                values (%s, %s, %s, %s, %s) returning id"""
-            ),
-            arguments,
-        )
-        self.attach_modified_fields_to_event(event_id, event, position)
-
-    def create_model(self, fqid: Fqid, model: Model, position: Position) -> None:
-        model[META_DELETED] = False
-        self._set_model(fqid, model, position)
-
-    def update_model(
-        self,
-        fqid: Fqid,
-        field_values: Dict[Field, JSON],
-        position: Position,
-        get_deleted_models=DeletedModelsBehaviour.NO_DELETED,
-    ) -> None:
-        model = self.read_database.get(fqid, get_deleted_models=get_deleted_models)
-        for field, value in field_values.items():
-            if value is None:
-                model.pop(field, None)
-            else:
-                model[field] = value
-        self._set_model(fqid, model, position)
-
-    def delete_model(self, fqid: str, position: Position) -> None:
-        self.update_model(fqid, {META_DELETED: True}, position)
-
-    def restore_model(self, fqid: str, position: Position) -> None:
-        self.update_model(
-            fqid,
-            {META_DELETED: False},
-            position,
-            get_deleted_models=DeletedModelsBehaviour.ONLY_DELETED,
-        )
-
-    def _set_model(self, fqid: str, model: Model, position: Position) -> None:
-        """META_DELETED must be in `model`"""
-        model[META_POSITION] = position
-        statement = """
-            insert into models (fqid, data, deleted) values (%s, %s, %s)
-            on conflict(fqid) do update set data=excluded.data, deleted=excluded.deleted;"""
-        self.connection.execute(
-            statement, [fqid, self.json(model), model[META_DELETED]]
-        )
-
-    def insert_create_event(
-        self, create_event: DbCreateEvent, position: Position, event_weight: int
-    ) -> None:
-        if self.exists_query("models", "fqid=%s", [create_event.fqid]):
-            raise ModelExists(create_event.fqid)
-
-        # update max collection id if neccessary
+    def write_model_updates(self, models: Dict[Fqid, Model]) -> None:
         statement = dedent(
             """\
-            insert into id_sequences (collection, id) values (%s, %s)
+            insert into models (fqid, data, deleted) values %s
+            on conflict(fqid) do update set data=excluded.data, deleted=excluded.deleted;"""
+        )
+        self.connection.execute(
+            statement,
+            [
+                (fqid, self.json(model), model[META_DELETED])
+                for fqid, model in models.items()
+            ],
+            use_execute_values=True,
+        )
+
+    def update_id_sequences(self, max_id_per_collection: Dict[Collection, int]) -> None:
+        statement = dedent(
+            """\
+            insert into id_sequences (collection, id) values %s
             on conflict(collection) do update
             set id=greatest(id_sequences.id, excluded.id);"""
         )
-        arguments: List[Any] = [
-            collection_from_fqid(create_event.fqid),
-            int(id_from_fqid(create_event.fqid)) + 1,
-        ]
-        self.connection.execute(statement, arguments)
+        arguments = list(max_id_per_collection.items())
+        self.connection.execute(statement, arguments, use_execute_values=True)
 
-        arguments = [
-            position,
-            create_event.fqid,
-            EVENT_TYPES.CREATE,
-            self.json(create_event.field_data),
-            event_weight,
-        ]
-        self.insert_db_event(create_event, arguments, position)
-
-        self.create_model(create_event.fqid, create_event.field_data, position)
-
-    def insert_update_event(
-        self, update_event, position: Position, event_weight: int
-    ) -> None:
-        self.assert_exists(update_event.fqid)
-
-        arguments = [
-            position,
-            update_event.fqid,
-            EVENT_TYPES.UPDATE,
-            self.json(update_event.field_data),
-            event_weight,
-        ]
-        self.insert_db_event(update_event, arguments, position)
-
-        self.update_model(
-            update_event.fqid, update_event.get_modified_fields(), position
+    def write_events(self, events_data: List[EventData]) -> List[int]:
+        return self.connection.query_list_of_single_values(
+            "insert into events (position, fqid, type, data, weight) values %s returning id",
+            events_data,
+            use_execute_values=True,
         )
-
-    def insert_list_update_event(
-        self,
-        list_update_event: DbListUpdateEvent,
-        position: Position,
-        event_weight: int,
-    ) -> None:
-        self.assert_exists(list_update_event.fqid)
-
-        data = {"add": list_update_event.add, "remove": list_update_event.remove}
-        arguments = [
-            position,
-            list_update_event.fqid,
-            EVENT_TYPES.LIST_FIELDS,
-            self.json(data),
-            event_weight,
-        ]
-        self.insert_db_event(list_update_event, arguments, position)
-
-        self.update_model(
-            list_update_event.fqid, list_update_event.get_modified_fields(), position
-        )
-
-    def insert_delete_fields_event(
-        self, delete_fields_event, position: Position, event_weight: int
-    ) -> None:
-        self.assert_exists(delete_fields_event.fqid)
-
-        arguments = [
-            position,
-            delete_fields_event.fqid,
-            EVENT_TYPES.DELETE_FIELDS,
-            self.json(delete_fields_event.fields),
-            event_weight,
-        ]
-        self.insert_db_event(delete_fields_event, arguments, position)
-
-        self.update_model(
-            delete_fields_event.fqid,
-            delete_fields_event.get_modified_fields(),
-            position,
-        )
-
-    def insert_delete_event(
-        self, delete_event, position: Position, event_weight: int
-    ) -> None:
-        self.assert_exists(delete_event.fqid)
-
-        arguments = [
-            position,
-            delete_event.fqid,
-            EVENT_TYPES.DELETE,
-            self.json(None),
-            event_weight,
-        ]
-        self.insert_db_event(delete_event, arguments, position)
-
-        self.delete_model(delete_event.fqid, position)
-
-    def insert_restore_event(
-        self, restore_event, position: Position, event_weight: int
-    ) -> None:
-        if not self.exists_query(
-            "models", "fqid=%s and deleted=%s", [restore_event.fqid, True]
-        ):
-            raise ModelNotDeleted(restore_event.fqid)
-
-        arguments = [
-            position,
-            restore_event.fqid,
-            EVENT_TYPES.RESTORE,
-            self.json(None),
-            event_weight,
-        ]
-        self.insert_db_event(restore_event, arguments, position)
-
-        self.restore_model(restore_event.fqid, position)
-
-    def assert_exists(self, fqid):
-        if not self.exists_query("models", "fqid=%s and deleted=%s", [fqid, False]):
-            raise ModelDoesNotExist(fqid)
-
-    def exists_query(self, table, conditions, arguments):
-        query = f"select exists(select 1 from {table} where {conditions})"
-        result = self.connection.query_single_value(query, arguments)
-        return result
-
-    def attach_modified_fields_to_event(self, event_id, event, position):
-        modified_collectionfields = self.get_modified_collectionfields_from_event(event)
-        if not modified_collectionfields:
-            return
-
-        collectionfield_ids = self.insert_modified_collectionfields_into_db(
-            modified_collectionfields, position
-        )
-        self.connect_events_and_collection_fields(event_id, collectionfield_ids)
 
     def get_modified_collectionfields_from_event(self, event):
         return [
@@ -328,53 +218,55 @@ class SqlDatabaseBackendService:
         ]
 
     def insert_modified_collectionfields_into_db(
-        self, modified_collectionfields, position
+        self, modified_collectionfields: Iterable[str], position: Position
     ):
         # insert into db, updating all existing fields with position, returning ids
-        value_placeholders = []
-        arguments: List[Any] = []
+        arguments = []
         for collectionfield in modified_collectionfields:
             if len(collectionfield) > COLLECTIONFIELD_MAX_LEN:
                 raise InvalidFormat(
-                    f"Collection field {collectionfield} is too long "
-                    + "(max: {COLLECTIONFIELD_MAX_LEN})"
+                    f"Collection field {collectionfield} is too long (max: {COLLECTIONFIELD_MAX_LEN})"
                 )
-            arguments.extend(
+            arguments.append(
                 (
                     collectionfield,
                     position,
                 )
             )
-            value_placeholders.append("(%s, %s)")
 
-        values = ",".join(value_placeholders)
         statement = dedent(
-            f"""\
-            insert into collectionfields (collectionfield, position) values {values}
+            """\
+            insert into collectionfields (collectionfield, position) values %s
             on conflict(collectionfield) do update set position=excluded.position
             returning id"""
         )
-        return self.connection.query_list_of_single_values(statement, arguments)
+        return self.connection.query_list_of_single_values(
+            statement, arguments, use_execute_values=True
+        )
 
-    def connect_events_and_collection_fields(self, event_id, collectionfield_ids):
-        # create m2m relations
-        value_placeholders = []
-        arguments: List[Any] = []
-        for collectionfield_id in collectionfield_ids:
+    def connect_events_and_collection_fields(
+        self,
+        event_ids: List[int],
+        collectionfield_ids: List[int],
+        event_indices_order: Iterable[List[int]],
+    ):
+        arguments: List[Tuple[int, int]] = []
+        for collectionfield_id, event_indices in zip(
+            collectionfield_ids, event_indices_order
+        ):
             arguments.extend(
                 (
-                    event_id,
+                    event_ids[event_index],
                     collectionfield_id,
                 )
+                for event_index in event_indices
             )
-            value_placeholders.append("(%s, %s)")
 
-        values = ",".join(value_placeholders)
-        statement = f"insert into events_to_collectionfields (event_id, collectionfield_id) values {values}"
-        self.connection.execute(statement, arguments)
+        statement = "insert into events_to_collectionfields (event_id, collectionfield_id) values %s"
+        self.connection.execute(statement, arguments, use_execute_values=True)
 
     def json(self, data):
-        return self.connection.to_json(data)
+        return self.connection.to_json(deepcopy(data))
 
     def reserve_next_ids(self, collection: str, amount: int) -> List[Id]:
         if amount <= 0:

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -28,11 +28,11 @@ Utility:
 
 Development environment:
 - `make build-dev`: builds all development images
-- `make run-dev`: runs the development environment
-- `make run-dev-verbose`: same as `make run-dev`, but doesn't detach the containers so the output is directly visible and the process can be stopped with CTRL+C.
+- `make run-dev-standalone`: runs the development environment
+- `make run-dev-verbose`: same as `make run-dev-standalone`, but doesn't detach the containers so the output is directly visible and the process can be stopped with CTRL+C.
 - `make stop-dev`: stops all dev containers
 
 All these commands are also available inside the modules and only affect the current module there. Additional commands available inside the modules (primarily for testing purposes):
 
-- `make run-bash`, `make run-tests-interactive`: opens a bash console in the container, so tests/cleanup can be run interactively
+- `make run-bash`, `make run-dev`: opens a bash console in the container, so tests/cleanup can be run interactively
 - `make run-coverage`: creates a coverage report for all tests. The needed coverage to pass is defined in `scripts/.coveragerc`.

--- a/tests/migrations/system/test_finalize_noop_migration.py
+++ b/tests/migrations/system/test_finalize_noop_migration.py
@@ -103,7 +103,7 @@ class Base:
         migration_handler.register_migrations(get_noop_migration(2))
         self.write_data(
             write,
-            {"type": "create", "fqid": "a/1", "fields": {}},
+            {"type": "create", "fqid": "a/1", "fields": {"f": 1}},
             {"type": "create", "fqid": "a/3", "fields": {}},
             {"type": "create", "fqid": "b/5", "fields": {}},
         )

--- a/tests/reader/system/get/test_get.py
+++ b/tests/reader/system/get/test_get.py
@@ -2,7 +2,7 @@ import json
 
 from datastore.reader.flask_frontend.routes import Route
 from datastore.shared.flask_frontend.errors import ERROR_CODES
-from datastore.shared.postgresql_backend import EVENT_TYPES
+from datastore.shared.postgresql_backend import EVENT_TYPE
 from datastore.shared.util import DeletedModelsBehaviour
 from tests.reader.system.util import setup_data
 from tests.util import assert_error_response, assert_success_response
@@ -126,11 +126,11 @@ def setup_events_data(connection, cursor):
     )
     cursor.execute(
         "insert into events (position, fqid, type, data, weight) values (1, %s, %s, %s, 1)",
-        [FQID, EVENT_TYPES.CREATE, data_json],
+        [FQID, EVENT_TYPE.CREATE, data_json],
     )
     cursor.execute(
         "insert into events (position, fqid, type, data, weight) values (2, %s, %s, %s, 2)",
-        [FQID, EVENT_TYPES.UPDATE, json.dumps({"field_1": "other"})],
+        [FQID, EVENT_TYPE.UPDATE, json.dumps({"field_1": "other"})],
     )
     connection.commit()
 
@@ -153,7 +153,7 @@ def test_position_deleted(json_client, db_connection, db_cur):
     setup_events_data(db_connection, db_cur)
     db_cur.execute(
         "insert into events (position, fqid, type, weight) values (3, %s, %s, 3)",
-        [FQID, EVENT_TYPES.DELETE],
+        [FQID, EVENT_TYPE.DELETE],
     )
     db_connection.commit()
     response = json_client.post(Route.GET.URL, {"fqid": FQID, "position": 3})
@@ -204,19 +204,19 @@ def test_order(json_client, db_connection, db_cur):
     # Do not reorder - the ids are implicitly chosen form 1-4
     db_cur.execute(
         "insert into events (position, fqid, type, data, weight) values (2, %s, %s, %s, 2)",
-        [FQID, EVENT_TYPES.RESTORE, json.dumps(None)],
+        [FQID, EVENT_TYPE.RESTORE, json.dumps(None)],
     )
     db_cur.execute(
         "insert into events (position, fqid, type, data, weight) values (2, %s, %s, %s, 1)",
-        [FQID, EVENT_TYPES.DELETE, json.dumps(None)],
+        [FQID, EVENT_TYPE.DELETE, json.dumps(None)],
     )
     db_cur.execute(
         "insert into events (position, fqid, type, data, weight) values (1, %s, %s, %s, 2)",
-        [FQID, EVENT_TYPES.UPDATE, json.dumps({"field_1": "other"})],
+        [FQID, EVENT_TYPE.UPDATE, json.dumps({"field_1": "other"})],
     )
     db_cur.execute(
         "insert into events (position, fqid, type, data, weight) values (1, %s, %s, %s, 1)",
-        [FQID, EVENT_TYPES.CREATE, data_json],
+        [FQID, EVENT_TYPE.CREATE, data_json],
     )
     db_connection.commit()
 

--- a/tests/reader/system/get_many/test_get_many.py
+++ b/tests/reader/system/get_many/test_get_many.py
@@ -2,7 +2,7 @@ import json
 
 from datastore.reader.flask_frontend.routes import Route
 from datastore.shared.flask_frontend import ERROR_CODES
-from datastore.shared.postgresql_backend import EVENT_TYPES
+from datastore.shared.postgresql_backend import EVENT_TYPE
 from datastore.shared.util import (
     META_DELETED,
     META_POSITION,
@@ -255,12 +255,12 @@ def setup_events_data(connection, cursor):
             cursor.execute(
                 "insert into events (position, fqid, type, data, weight) \
                 values (1, %s, %s, %s, 1)",
-                [fqid, EVENT_TYPES.CREATE, json.dumps(model_data)],
+                [fqid, EVENT_TYPE.CREATE, json.dumps(model_data)],
             )
             cursor.execute(
                 "insert into events (position, fqid, type, data, weight) \
                 values (2, %s, %s, %s, 2)",
-                [fqid, EVENT_TYPES.UPDATE, json.dumps({"common_field": 0})],
+                [fqid, EVENT_TYPE.UPDATE, json.dumps({"common_field": 0})],
             )
     connection.commit()
 
@@ -309,11 +309,11 @@ def test_position_deleted(json_client, db_connection, db_cur):
     setup_events_data(db_connection, db_cur)
     db_cur.execute(
         "insert into events (position, fqid, type, weight) values (3, %s, %s, 3)",
-        ["b/1", EVENT_TYPES.DELETE],
+        ["b/1", EVENT_TYPE.DELETE],
     )
     db_cur.execute(
         "insert into events (position, fqid, type, weight) values (4, %s, %s, 4)",
-        ["b/1", EVENT_TYPES.RESTORE],
+        ["b/1", EVENT_TYPE.RESTORE],
     )
     db_connection.commit()
     request = {
@@ -349,7 +349,7 @@ def test_position_not_deleted(json_client, db_connection, db_cur):
     setup_events_data(db_connection, db_cur)
     db_cur.execute(
         "insert into events (position, fqid, type, weight) values (3, %s, %s, 3)",
-        ["b/1", EVENT_TYPES.DELETE],
+        ["b/1", EVENT_TYPE.DELETE],
     )
     db_connection.commit()
     request = {

--- a/tests/reader/system/history_information/test_history_information.py
+++ b/tests/reader/system/history_information/test_history_information.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 
 from datastore.reader.flask_frontend.routes import Route
-from datastore.shared.postgresql_backend import EVENT_TYPES
+from datastore.shared.postgresql_backend import EVENT_TYPE
 from tests.util import assert_success_response
 
 
@@ -19,7 +19,7 @@ def setup(db_connection, db_cur):
         position = db_cur.fetchone()[0]
         db_cur.execute(
             "insert into events (position, fqid, type, data, weight) values (%s, %s, %s, %s, 1)",
-            [position, fqid, EVENT_TYPES.CREATE, json.dumps({})],
+            [position, fqid, EVENT_TYPE.CREATE, json.dumps({})],
         )
         db_connection.commit()
 

--- a/tests/reader/system/util.py
+++ b/tests/reader/system/util.py
@@ -1,6 +1,6 @@
 import json
 
-from datastore.shared.postgresql_backend import EVENT_TYPES
+from datastore.shared.postgresql_backend import EVENT_TYPE
 from datastore.shared.util import META_POSITION, strip_reserved_fields
 
 
@@ -18,7 +18,7 @@ def setup_data(connection, cursor, models, deleted=False):
             [
                 model[META_POSITION],
                 fqid,
-                EVENT_TYPES.CREATE,
+                EVENT_TYPE.CREATE,
                 json.dumps(data),
                 weight,
             ],

--- a/tests/shared/unit/postgresql_backend/test_pg_connection_handler.py
+++ b/tests/shared/unit/postgresql_backend/test_pg_connection_handler.py
@@ -254,7 +254,7 @@ def test_query_single_value_none(handler):
 def test_query_list_of_single_values(handler):
     handler.query = MagicMock()
     handler.query_list_of_single_values("", "")
-    handler.query.assert_called_with("", "", [])
+    handler.query.assert_called_with("", "", [], False)
 
 
 def test_shutdown(handler):

--- a/tests/shared/unit/postgresql_backend/test_sql_read_database_backend_service.py
+++ b/tests/shared/unit/postgresql_backend/test_sql_read_database_backend_service.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from datastore.shared.di import injector
-from datastore.shared.postgresql_backend import EVENT_TYPES, ConnectionHandler
+from datastore.shared.postgresql_backend import EVENT_TYPE, ConnectionHandler
 from datastore.shared.postgresql_backend.connection_handler import DatabaseError
 from datastore.shared.postgresql_backend.sql_query_helper import SqlQueryHelper
 from datastore.shared.postgresql_backend.sql_read_database_backend_service import (
@@ -260,7 +260,7 @@ def test_build_model_from_events_unknown_event(read_database: ReadDatabase):
     with pytest.raises(BadCodingError):
         read_database.build_model_from_events(
             [
-                {"type": EVENT_TYPES.CREATE, "data": MagicMock()},
+                {"type": EVENT_TYPE.CREATE, "data": MagicMock()},
                 {"type": MagicMock(), "data": MagicMock()},
             ]
         )
@@ -273,9 +273,9 @@ def test_build_model_from_events_delete_fields_event(read_database: ReadDatabase
 
     result = read_database.build_model_from_events(
         [
-            {"type": EVENT_TYPES.CREATE, "data": base_model},
+            {"type": EVENT_TYPE.CREATE, "data": base_model},
             {
-                "type": EVENT_TYPES.DELETE_FIELDS,
+                "type": EVENT_TYPE.DELETE_FIELDS,
                 "data": delete_fields_event,
                 "position": 0,
             },
@@ -316,7 +316,7 @@ def test_get_deleted_status_position(
     read_database: ReadDatabase, connection: ConnectionHandler
 ):
     fqid = MagicMock()
-    result = [{"fqid": fqid, "type": EVENT_TYPES.DELETE}]
+    result = [{"fqid": fqid, "type": EVENT_TYPE.DELETE}]
     connection.query = q = MagicMock(return_value=result)
 
     assert read_database.get_deleted_status([fqid], 42) == {fqid: True}

--- a/tests/util.py
+++ b/tests/util.py
@@ -55,7 +55,7 @@ class TestPerformance:
             **{
                 method_name: self._performance_decorator(orig_methods[method_name])
                 for method_name in self.query_methods
-            }
+            },
         )
         self.patcher.start()
         self.performance_info = {

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,10 @@
+from time import time
+from unittest.mock import patch
+
+from datastore.shared.di import injector
+from datastore.shared.postgresql_backend import ConnectionHandler
+
+
 def assert_response_code(response, code):
     if response.status_code != code:
         print(response.json() if callable(response.json) else response.json)
@@ -19,3 +26,61 @@ def assert_success_response(response):
 
 def assert_no_newline_in_json(response):
     assert "\n" not in response.get_data(as_text=True)
+
+
+class TestPerformance:
+    """
+    Useful for testing the performance of certain requests in system tests. Automatically patches
+    all relevant methods of the used connection handler to count and measure the requests in
+    addition to measuring the total time used. Example usage:
+    ```
+    with TestPerformance() as performance:
+        response = json_client.post(url, data)
+
+    print(f"{performance['total_time']} seconds")
+    print(f"requests: {performance['requests_count']}")
+    print(f"read time: {performance['read_time']}, write time: {performance['write_time']}")
+    ```
+    """
+
+    query_methods = ("execute", "query", "query_single_value")
+
+    def __enter__(self):
+        orig_methods = {}
+        connection_handler = injector.get(ConnectionHandler)
+        for method_name in self.query_methods:
+            orig_methods[method_name] = getattr(connection_handler, method_name)
+        self.patcher = patch.multiple(
+            connection_handler,
+            **{
+                method_name: self._performance_decorator(orig_methods[method_name])
+                for method_name in self.query_methods
+            }
+        )
+        self.patcher.start()
+        self.performance_info = {
+            "read_time": 0.0,
+            "write_time": 0.0,
+            "requests_count": 0,
+        }
+        self.start_time = time()
+        return self.performance_info
+
+    def __exit__(self, exception, exception_value, traceback):
+        diff = time() - self.start_time
+        self.patcher.stop()
+        self.performance_info["total_time"] = diff
+
+    def _performance_decorator(self, fn):
+        def wrapper(query, *args, **kwargs):
+            self.performance_info["requests_count"] += 1
+            start = time()
+            result = fn(query, *args, **kwargs)
+            diff = time() - start
+            if query.strip().lower().startswith("select"):
+                self.performance_info["read_time"] += diff
+            else:
+                self.performance_info["write_time"] += diff
+            return result
+
+        return wrapper

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,12 @@
+import os
 from time import time
 from unittest.mock import patch
 
+import pytest
+
 from datastore.shared.di import injector
 from datastore.shared.postgresql_backend import ConnectionHandler
+from datastore.shared.services.environment_service import is_truthy
 
 
 def assert_response_code(response, code):
@@ -26,6 +30,13 @@ def assert_success_response(response):
 
 def assert_no_newline_in_json(response):
     assert "\n" not in response.get_data(as_text=True)
+
+
+def performance(func):
+    return pytest.mark.skipif(
+        not is_truthy(os.environ.get("OPENSLIDES_PERFORMANCE_TESTS", "")),
+        reason="Performance tests are disabled.",
+    )(func)
 
 
 class TestPerformance:

--- a/tests/writer/integration/write/test_insert_events.py
+++ b/tests/writer/integration/write/test_insert_events.py
@@ -6,7 +6,7 @@ import pytest
 from datastore.shared.di import injector
 from datastore.shared.postgresql_backend import ConnectionHandler
 from datastore.shared.services import EnvironmentService, ReadDatabase
-from datastore.shared.util import ModelDoesNotExist, ModelExists
+from datastore.shared.util import META_DELETED, ModelDoesNotExist, ModelExists
 from datastore.writer.core import (
     Database,
     Messaging,
@@ -26,45 +26,49 @@ class FakeConnectionHandler:
     def get_connection_context(self):
         return MagicMock()
 
-    def execute(self, statement, arguments):
-        if statement.strip().startswith("insert into positions ("):
-            self.create_position(statement, arguments)
-        if statement.strip().startswith("insert into models ("):
-            self.create_model_lookup(statement, arguments)
-
-    def create_position(self, statement, arguments):
-        """"""
-
-    def create_model_lookup(self, statement, arguments):
-        """"""
+    def execute(self, query, arguments, use_execute_values=False):
+        return self._query(query, arguments, use_execute_values)
 
     def query_single_value(self, query, arguments):
-        print("query", query, arguments, "\n")
-        if query == "select max(position) from positions":
-            return self.get_max_position()
-        if query.strip().startswith("select exists(select 1"):
-            return self.exists()
-        if query.strip().startswith("insert into events ("):
-            return self.create_event(query, arguments)
+        return self._query(query, arguments)
 
-    def get_max_position(self):
-        """"""
-
-    def exists(self):
-        """"""
-
-    def create_event(self, query, arguments):
-        """"""
-
-    def query_list_of_single_values(self, query, arguments):
-        if query.startswith("insert into collectionfields (collectionfield, position)"):
-            return self.attach_fields()
-
-    def attach_fields(self):
-        """"""
+    def query_list_of_single_values(self, query, arguments, use_execute_values=False):
+        return self._query(query, arguments, use_execute_values)
 
     def to_json(self, data):
         return data
+
+    def _query(self, query, arguments, use_execute_values=False):
+        if query.strip().startswith("insert into positions ("):
+            return self._create_position(query, arguments)
+        if query.strip().startswith("insert into models ("):
+            return self._update_models(query, arguments)
+        if query.strip().startswith("insert into id_sequences ("):
+            return self._update_id_sequences(query, arguments)
+        if query.strip().startswith("insert into events ("):
+            return self._create_events(query, arguments)
+        if query.strip().startswith("insert into collectionfields ("):
+            return self._attach_fields_to_positions(query, arguments)
+        if query.strip().startswith("insert into events_to_collectionfields ("):
+            return self._attach_fields_to_events(query, arguments)
+
+    def _create_position(self, query, arguments):
+        """"""
+
+    def _update_models(self, query, arguments):
+        """"""
+
+    def _update_id_sequences(self, query, arguments):
+        """"""
+
+    def _create_events(self, query, arguments):
+        """"""
+
+    def _attach_fields_to_positions(self, query, arguments):
+        """"""
+
+    def _attach_fields_to_events(self, query, arguments):
+        """"""
 
 
 @pytest.fixture(autouse=True)
@@ -90,23 +94,84 @@ def connection_handler():
 
 
 @pytest.fixture()
+def read_db():
+    yield injector.get(ReadDatabase)
+
+
+@pytest.fixture()
 def valid_metadata():
     yield copy.deepcopy(
         {"user_id": 1, "information": {}, "locked_fields": {}, "events": []}
     )
 
 
-def test_insert_create_event(write_handler, connection_handler, valid_metadata):
+def test_insert_create_event(
+    write_handler, connection_handler, valid_metadata, read_db
+):
+    fqid = "a/1"
     valid_metadata["events"].append(
-        {"type": "create", "fqid": "a/1", "fields": {"f": 1}}  # this is allowed
+        {"type": "create", "fqid": fqid, "fields": {"f": 1}}
     )
-    connection_handler.create_position = cp = MagicMock()
     position = MagicMock()
-    connection_handler.get_max_position = MagicMock(return_value=position)
-    connection_handler.exists = MagicMock(return_value=None)
-    connection_handler.create_model_lookup = cml = MagicMock()
-    connection_handler.create_event = ce = MagicMock()
-    connection_handler.attach_fields = af = MagicMock(return_value=[])
+    connection_handler._create_position = cp = MagicMock(return_value=position)
+    connection_handler._update_models = um = MagicMock()
+    connection_handler._update_id_sequences = uis = MagicMock()
+    event_id = MagicMock()
+    connection_handler._create_events = ce = MagicMock(return_value=[event_id])
+    collectionfield_id = MagicMock()
+    connection_handler._attach_fields_to_positions = afp = MagicMock(
+        return_value=[collectionfield_id]
+    )
+    connection_handler._attach_fields_to_events = afe = MagicMock()
+    read_db.get_many = gm = MagicMock(return_value={})
+
+    write_handler.write(valid_metadata)
+
+    cp.assert_called_once()
+    gm.assert_called_once()
+    um.assert_called_once()
+    assert fqid in um.call_args.args[1][0]
+
+    uis.assert_called_once()
+    ce.assert_called_once()
+    assert fqid in ce.call_args.args[1][0]
+    assert position in ce.call_args.args[1][0]
+
+    afp.assert_called_once()
+    afe.assert_called_once()
+
+
+def test_insert_create_event_already_exists(
+    write_handler, connection_handler, valid_metadata, read_db
+):
+    fqid = "a/1"
+    valid_metadata["events"].append({"type": "create", "fqid": fqid, "fields": {}})
+    connection_handler._create_position = cp = MagicMock()
+    connection_handler._create_events = ce = MagicMock()
+    read_db.get_many = MagicMock(return_value={fqid: {}})
+
+    with pytest.raises(ModelExists) as e:
+        write_handler.write(valid_metadata)
+
+    cp.assert_called_once()
+    assert fqid == e.value.fqid
+    assert ce.call_count == 0
+
+
+def test_combined_update_delete_fields_events(
+    write_handler, connection_handler, valid_metadata, read_db
+):
+    fqid = "a/1"
+    valid_metadata["events"].append(
+        {"type": "update", "fqid": "a/1", "fields": {"f": 1, "none": None}}
+    )
+    position = MagicMock()
+    connection_handler._create_position = cp = MagicMock(return_value=position)
+    connection_handler._create_events = ce = MagicMock()
+    connection_handler._attach_fields_to_positions = af = MagicMock()
+    read_db.get_many = MagicMock(
+        return_value={fqid: {"none": "a", META_DELETED: False}}
+    )
 
     write_handler.write(valid_metadata)
 
@@ -114,70 +179,22 @@ def test_insert_create_event(write_handler, connection_handler, valid_metadata):
     ce.assert_called_once()
     af.assert_called_once()
     # check if position is in the arguments
-    assert position in ce.call_args.args[1]
-
-    cml.assert_called_once()
-    # check if fqid is in the arguments
-    assert "a/1" in cml.call_args.args[1]
-
-
-def test_insert_create_event_already_exists(
-    write_handler, connection_handler, valid_metadata
-):
-    valid_metadata["events"].append(
-        {"type": "create", "fqid": "a/1", "fields": {}}  # this is allowed
-    )
-    connection_handler.create_position = cp = MagicMock()
-    connection_handler.get_max_position = MagicMock()
-    connection_handler.exists = MagicMock(return_value=True)
-    connection_handler.create_event = ce = MagicMock()
-
-    with pytest.raises(ModelExists) as e:
-        write_handler.write(valid_metadata)
-
-    cp.assert_called_once()
-    assert "a/1" == e.value.fqid
-    assert ce.call_count == 0
-
-
-def test_combined_update_delete_fields_events(
-    write_handler, connection_handler, valid_metadata
-):
-    valid_metadata["events"].append(
-        {"type": "update", "fqid": "a/1", "fields": {"f": 1, "none": None}}
-    )
-    connection_handler.create_position = cp = MagicMock()
-    position = MagicMock()
-    connection_handler.get_max_position = MagicMock(return_value=position)
-    connection_handler.exists = exists = MagicMock(return_value=True)
-    connection_handler.create_event = ce = MagicMock()
-    connection_handler.attach_fields = af = MagicMock(return_value=[])
-
-    write_handler.write(valid_metadata)
-
-    cp.assert_called_once()
-    assert exists.call_count == 2
-    assert ce.call_count == 2
-    assert af.call_count == 2
-    # check if position is in the arguments
-    assert position in ce.call_args_list[0].args[1]
-    assert position in ce.call_args_list[1].args[1]
+    assert position in ce.call_args.args[1][0]
 
 
 def test_combined_update_delete_fields_events_model_not_existent(
-    write_handler, connection_handler, valid_metadata
+    write_handler, connection_handler, valid_metadata, read_db
 ):
     valid_metadata["events"].append(
         {"type": "update", "fqid": "a/1", "fields": {"f": 1, "none": None}}
     )
-    connection_handler.create_position = cp = MagicMock()
-    connection_handler.get_max_position = MagicMock()
-    connection_handler.exists = MagicMock(return_value=None)
-    connection_handler.create_event = ce = MagicMock()
+    connection_handler._create_position = cp = MagicMock()
+    connection_handler._create_events = ce = MagicMock()
+    read_db.get_many = MagicMock(return_value={})
 
     with pytest.raises(ModelDoesNotExist) as e:
         write_handler.write(valid_metadata)
 
     cp.assert_called_once()
     assert "a/1" == e.value.fqid
-    assert ce.call_count == 0
+    ce.assert_not_called()

--- a/tests/writer/system/util.py
+++ b/tests/writer/system/util.py
@@ -4,7 +4,7 @@ import pytest
 
 from datastore.shared.di import injector
 from datastore.shared.postgresql_backend import ALL_TABLES, ConnectionHandler
-from datastore.shared.postgresql_backend.sql_event_types import EVENT_TYPES
+from datastore.shared.postgresql_backend.sql_event_types import EVENT_TYPE
 from datastore.shared.services import ReadDatabase
 from datastore.shared.typing import Field, Fqid
 from datastore.shared.util import (
@@ -39,7 +39,7 @@ def assert_model(fqid, model, position):
         assert (
             isinstance(event_type, str)
             and len(event_type) > 0
-            and event_type != EVENT_TYPES.DELETE
+            and event_type != EVENT_TYPE.DELETE
         )
 
 
@@ -57,7 +57,7 @@ def assert_no_model(fqid):
             "select type from events where fqid=%s order by position desc, weight desc limit 1",
             [fqid],
         )
-        assert event_type in (EVENT_TYPES.DELETE, None)
+        assert event_type in (EVENT_TYPE.DELETE, None)
 
 
 def assert_no_db_entry(db_cur):

--- a/tests/writer/system/write/test_multiple.py
+++ b/tests/writer/system/write/test_multiple.py
@@ -4,7 +4,12 @@ import pytest
 
 from datastore.shared.flask_frontend import ERROR_CODES
 from datastore.writer.flask_frontend.routes import WRITE_URL
-from tests.util import TestPerformance, assert_error_response, assert_response_code
+from tests.util import (
+    TestPerformance,
+    assert_error_response,
+    assert_response_code,
+    performance,
+)
 from tests.writer.system.util import (
     assert_model,
     assert_modified_fields,
@@ -159,9 +164,9 @@ def test_delete_update(json_client, data, redis_connection, reset_redis_data):
     assert_error_response(response, ERROR_CODES.MODEL_DOES_NOT_EXIST)
 
 
-@pytest.mark.skip(reason="Time-intensive performance test")
+@performance
 def test_update_performance(json_client, data, redis_connection, reset_redis_data):
-    MODEL_COUNT = 1000
+    MODEL_COUNT = 10000
     data["events"] = [
         {"type": "create", "fqid": f"a/{i}", "fields": {"f1": 1, "f2": 2, "f3": 3}}
         for i in range(1, MODEL_COUNT + 1)

--- a/tests/writer/unit/postgresql_backend/test_db_events.py
+++ b/tests/writer/unit/postgresql_backend/test_db_events.py
@@ -18,6 +18,11 @@ def test_base_db_event_get_modified_fields():
         BaseDbEvent("a/1").get_modified_fields()
 
 
+def test_base_db_event_get_event_data():
+    with pytest.raises(NotImplementedError):
+        BaseDbEvent("a/1").get_event_data()
+
+
 def test_db_create_event():
     fqid = MagicMock()
     value = MagicMock()

--- a/tests/writer/unit/postgresql_backend/test_sql_database_backend_service.py
+++ b/tests/writer/unit/postgresql_backend/test_sql_database_backend_service.py
@@ -225,6 +225,10 @@ class TestApplyEventToModels:
             META_DELETED: False,
         }
 
+    def test_invalid_event(self, sql_backend):
+        with pytest.raises(BadCodingError):
+            sql_backend.apply_event_to_models(MagicMock(), {}, MagicMock())
+
 
 def test_write_model_updates(sql_backend, connection):
     connection.execute = execute = MagicMock()


### PR DESCRIPTION
First results of this (heavily WIP) PR: Tested sending 10000 update events which each changed 3 fields and deleted 3 fields. Measured times:
* before: 36s
* after: 2.3s

So, looking very promising! Will finalize these change and check for more places for improvement.