### PR TITLE
pin version of protobuf

### DIFF
--- a/requirements/requirements-general.txt
+++ b/requirements/requirements-general.txt
@@ -8,3 +8,4 @@ opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp
 opentelemetry-instrumentation-flask
+protobuf==3.20.1


### PR DESCRIPTION
since a new release this leads to a traceback during intializing,
even if OTEL is not enabled.
see https://github.com/protocolbuffers/protobuf/issues/10051