### PR TITLE
add read-from-stdin to cli/import-events.sh for better compatibility

### DIFF
--- a/cli/import-events.sh
+++ b/cli/import-events.sh
@@ -2,17 +2,9 @@
 
 set -e
 
-DATASTORE_DATABASE_HOST=${DATASTORE_DATABASE_HOST:-postgres}
-DATASTORE_DATABASE_PORT=${DATASTORE_DATABASE_PORT:-5432}
-DATASTORE_DATABASE_USER=${DATASTORE_DATABASE_USER:-openslides}
-DATASTORE_DATABASE_NAME=${DATASTORE_DATABASE_NAME:-openslides}
-PGPASSWORD=${DATASTORE_DATABASE_PASSWORD}
-[ -z "$PGPASSWORD" ] || export PGPASSWORD
-PSQL="psql -h $DATASTORE_DATABASE_HOST -p $DATASTORE_DATABASE_PORT -U $DATASTORE_DATABASE_USER -d $DATASTORE_DATABASE_NAME"
-
 if [ $# -eq 0 ]; then
-    echo "No file to import from is given (use - to read from stdin)."
-    exit 1
+  echo "No file to import from is given (use - to read from stdin)."
+  exit 1
 fi
 
 SRC=
@@ -20,7 +12,6 @@ SRC=
   SRC="$1"
 
 # wait for potentially restarted postgres to become ready
-until $PSQL -c '\q' >/dev/null 2>&1; do
-  echo "waiting for $DATASTORE_DATABASE_HOST ..." && sleep 1
-done
-cat $SRC | $PSQL
+source wait-for-database.sh
+
+cat $SRC | psql -h "$DATASTORE_DATABASE_HOST" -p "$DATASTORE_DATABASE_PORT" -U "$DATASTORE_DATABASE_USER" -d "$DATASTORE_DATABASE_NAME"

--- a/cli/import-events.sh
+++ b/cli/import-events.sh
@@ -2,9 +2,25 @@
 
 set -e
 
+DATASTORE_DATABASE_HOST=${DATASTORE_DATABASE_HOST:-postgres}
+DATASTORE_DATABASE_PORT=${DATASTORE_DATABASE_PORT:-5432}
+DATASTORE_DATABASE_USER=${DATASTORE_DATABASE_USER:-openslides}
+DATASTORE_DATABASE_NAME=${DATASTORE_DATABASE_NAME:-openslides}
+PGPASSWORD=${DATASTORE_DATABASE_PASSWORD}
+[ -z "$PGPASSWORD" ] || export PGPASSWORD
+PSQL="psql -h $DATASTORE_DATABASE_HOST -p $DATASTORE_DATABASE_PORT -U $DATASTORE_DATABASE_USER -d $DATASTORE_DATABASE_NAME"
+
 if [ $# -eq 0 ]; then
-    echo "No file to import from is given."
+    echo "No file to import from is given (use - to read from stdin)."
     exit 1
 fi
 
-psql -h "$DATASTORE_DATABASE_HOST" -p "$DATASTORE_DATABASE_PORT" -U "$DATASTORE_DATABASE_USER" -d "$DATASTORE_DATABASE_NAME" < $1
+SRC=
+[ "$1" = "-" ] ||
+  SRC="$1"
+
+# wait for potentially restarted postgres to become ready
+until $PSQL -c '\q' >/dev/null 2>&1; do
+  echo "waiting for $DATASTORE_DATABASE_HOST ..." && sleep 1
+done
+cat $SRC | $PSQL


### PR DESCRIPTION
Reason for this is https://github.com/OpenSlides/OpenSlides/pull/6465
where I wanted to import SQL without needing to have the .sql file present in the containers file system.