### PR TITLE
Process create events first in migrations & remove empty events

### DIFF
--- a/datastore/migrations/core/events.py
+++ b/datastore/migrations/core/events.py
@@ -43,6 +43,8 @@ class BaseEvent:
 
 
 class _ModelEvent(BaseEvent):
+    data: Model
+
     def __init__(self, fqid: Fqid, data: Model) -> None:
         super().__init__(fqid, data)
 
@@ -66,6 +68,8 @@ class UpdateEvent(_ModelEvent):
 class DeleteFieldsEvent(BaseEvent):
     type = EVENT_TYPE.DELETE_FIELDS
 
+    data: List[Field]
+
     def __init__(self, fqid: Fqid, data: List[Field]) -> None:
         super().__init__(fqid, data)
 
@@ -78,6 +82,9 @@ class DeleteFieldsEvent(BaseEvent):
 
 class ListUpdateEvent(BaseEvent):
     type = EVENT_TYPE.LIST_FIELDS
+
+    add: ListUpdatesDict
+    remove: ListUpdatesDict
 
     def __init__(self, fqid: Fqid, data: Dict[str, ListUpdatesDict]) -> None:
         self.add = data.pop("add", {})

--- a/datastore/shared/typing.py
+++ b/datastore/shared/typing.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, NewType, TypeAlias, Union
 JSON = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 
 
-Model = Dict[str, JSON]
+Model = Dict[str, Any]
 
 _Collection = NewType("_Collection", str)
 _Field = NewType("_Field", str)

--- a/tests/migrations/system/test_filter_empty_events.py
+++ b/tests/migrations/system/test_filter_empty_events.py
@@ -1,0 +1,104 @@
+from datastore.migrations.core.events import (
+    BaseEvent,
+    DeleteFieldsEvent,
+    ListUpdateEvent,
+    UpdateEvent,
+)
+from tests.migrations.util import get_lambda_migration
+
+
+def test_filter_empty_update(
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_count,
+    assert_model,
+):
+    write({"type": "create", "fqid": "a/1", "fields": {"f": 1}})
+    write({"type": "update", "fqid": "a/1", "fields": {"f": 2}})
+    set_migration_index_to_1()
+
+    def remove_f(event: BaseEvent):
+        if isinstance(event, UpdateEvent):
+            del event.data["f"]
+        return [event]
+
+    migration_handler.register_migrations(get_lambda_migration(remove_f))
+    migration_handler.finalize()
+
+    assert_count("events", 1)
+    assert_model(
+        "a/1",
+        {
+            "f": 1,
+            "meta_deleted": False,
+            "meta_position": 1,
+        },
+    )
+
+
+def test_filter_empty_listupdate(
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_count,
+    assert_model,
+):
+    write({"type": "create", "fqid": "a/1", "fields": {"f": [1]}})
+    write(
+        {
+            "type": "update",
+            "fqid": "a/1",
+            "list_fields": {"add": {"f": [2]}, "remove": {"f": [1]}},
+        }
+    )
+    set_migration_index_to_1()
+
+    def remove_f(event: BaseEvent):
+        if isinstance(event, ListUpdateEvent):
+            del event.add["f"]
+            del event.remove["f"]
+        return [event]
+
+    migration_handler.register_migrations(get_lambda_migration(remove_f))
+    migration_handler.finalize()
+
+    assert_count("events", 1)
+    assert_model(
+        "a/1",
+        {
+            "f": [1],
+            "meta_deleted": False,
+            "meta_position": 1,
+        },
+    )
+
+
+def test_filter_empty_deletefields(
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_count,
+    assert_model,
+):
+    write({"type": "create", "fqid": "a/1", "fields": {"f": [1]}})
+    write({"type": "update", "fqid": "a/1", "fields": {"f": None}})
+    set_migration_index_to_1()
+
+    def remove_f(event: BaseEvent):
+        if isinstance(event, DeleteFieldsEvent):
+            event.data.remove("f")
+        return [event]
+
+    migration_handler.register_migrations(get_lambda_migration(remove_f))
+    migration_handler.finalize()
+
+    assert_count("events", 1)
+    assert_model(
+        "a/1",
+        {
+            "f": [1],
+            "meta_deleted": False,
+            "meta_position": 1,
+        },
+    )

--- a/tests/migrations/system/test_filter_empty_events.py
+++ b/tests/migrations/system/test_filter_empty_events.py
@@ -102,3 +102,30 @@ def test_filter_empty_deletefields(
             "meta_position": 1,
         },
     )
+
+
+def test_filter_no_events(
+    migration_handler,
+    write,
+    set_migration_index_to_1,
+    assert_count,
+    assert_model,
+):
+    write({"type": "create", "fqid": "a/1", "fields": {"f": 1}})
+    write({"type": "update", "fqid": "a/1", "fields": {"f": 2}})
+    set_migration_index_to_1()
+
+    migration_handler.register_migrations(
+        get_lambda_migration(lambda e: [] if isinstance(e, UpdateEvent) else None)
+    )
+    migration_handler.finalize()
+
+    assert_count("events", 1)
+    assert_model(
+        "a/1",
+        {
+            "f": 1,
+            "meta_deleted": False,
+            "meta_position": 1,
+        },
+    )

--- a/tests/migrations/system/test_migration_keyframes.py
+++ b/tests/migrations/system/test_migration_keyframes.py
@@ -350,7 +350,9 @@ class TestInitialMigrationKeyframeModifier(BaseTest):
     meta_position = 1
 
     def _write(self, write, *data):
-        write(*data, {"type": "create", "fqid": "trigger/1", "fields": {}})
+        if data:
+            write(*data)
+        write({"type": "create", "fqid": "trigger/1", "fields": {}})
 
 
 class TestDatabaseMigrationKeyframeModifier(BaseTest):
@@ -358,7 +360,9 @@ class TestDatabaseMigrationKeyframeModifier(BaseTest):
 
     def _write(self, write, *data):
         write({"type": "create", "fqid": "dummy/1", "fields": {}})
-        write(*data, {"type": "create", "fqid": "trigger/1", "fields": {}})
+        if data:
+            write(*data)
+        write({"type": "create", "fqid": "trigger/1", "fields": {}})
 
 
 class TestSkippedPositionMigrationKeyframeModifier(BaseTest):
@@ -372,4 +376,6 @@ class TestSkippedPositionMigrationKeyframeModifier(BaseTest):
             connection_handler.execute(
                 "ALTER SEQUENCE positions_position_seq RESTART WITH 3", []
             )
-        write(*data, {"type": "create", "fqid": "trigger/1", "fields": {"f": 1}})
+        if data:
+            write(*data)
+        write({"type": "create", "fqid": "trigger/1", "fields": {"f": 1}})

--- a/tests/migrations/system/test_premade_migration_classes.py
+++ b/tests/migrations/system/test_premade_migration_classes.py
@@ -211,7 +211,7 @@ def test_remove_field(
     )
     assert_model("a/1", {"a": 6, "meta_deleted": False, "meta_position": 2}, position=2)
     assert_model("a/1", {"a": 6, "meta_deleted": False, "meta_position": 3}, position=3)
-    assert_model("a/1", {"a": 6, "meta_deleted": False, "meta_position": 4}, position=4)
+    assert_model("a/1", {"a": 6, "meta_deleted": False, "meta_position": 3}, position=4)
     assert_model("a/1", {"a": 6, "meta_deleted": True, "meta_position": 5}, position=5)
     assert_model("a/1", {"a": 6, "meta_deleted": False, "meta_position": 6}, position=6)
     assert_model("a/1", {"a": 7, "meta_deleted": False, "meta_position": 7}, position=7)
@@ -230,7 +230,7 @@ def test_remove_field(
         "c/1", {"a": 6, "meta_deleted": False, "meta_position": 11}, position=11
     )
     assert_model(
-        "c/1", {"a": 6, "meta_deleted": False, "meta_position": 12}, position=12
+        "c/1", {"a": 6, "meta_deleted": False, "meta_position": 11}, position=12
     )
     assert_model(
         "c/1", {"a": 6, "meta_deleted": True, "meta_position": 13}, position=13

--- a/tests/migrations/system/test_sample_migrations.py
+++ b/tests/migrations/system/test_sample_migrations.py
@@ -117,10 +117,10 @@ def test_remove_field(
 
     assert_finalized()
     assert_model("a/1", {"meta_deleted": False, "meta_position": 1}, position=1)
-    assert_model("a/1", {"meta_deleted": False, "meta_position": 2}, position=2)
-    assert_model("a/1", {"meta_deleted": False, "meta_position": 3}, position=3)
-    assert_model("a/1", {"meta_deleted": False, "meta_position": 4}, position=4)
-    assert_model("a/1", {"meta_deleted": False, "meta_position": 5}, position=5)
+    assert_model("a/1", {"meta_deleted": False, "meta_position": 1}, position=2)
+    assert_model("a/1", {"meta_deleted": False, "meta_position": 1}, position=3)
+    assert_model("a/1", {"meta_deleted": False, "meta_position": 1}, position=4)
+    assert_model("a/1", {"meta_deleted": False, "meta_position": 1}, position=5)
 
 
 def test_add_required_field_based_on_migrated_data(


### PR DESCRIPTION
- sort events per position, so create events are processed first to prevent errors related to not-yet created models
- filter out empty (list) update and delete field events after migrations
- fix some typing issues