### PR TITLE
Ba issue1680 action worker deletion

### DIFF
--- a/datastore/writer/core/database.py
+++ b/datastore/writer/core/database.py
@@ -39,3 +39,6 @@ class Database(Protocol):
 
     def write_model_updates_action_worker(self, models: Dict[Fqid, Model]) -> None:
         """For writing directly to models-table used for action_workers"""
+
+    def write_model_deletes_action_worker(self, fqids: List[Fqid]) -> None:
+        """For deleting directly to models-table used for action_workers"""

--- a/datastore/writer/core/writer_service.py
+++ b/datastore/writer/core/writer_service.py
@@ -138,9 +138,8 @@ class WriterService:
 
         with make_span("write action worker"):
             self.position_to_modified_models = {}
-            fqids_to_delete: List[Fqid] = []
-            if type(write_request.events[0]) == RequestDeleteEvent:
-                """delete requests will be handled all together"""
+            if isinstance(write_request.events[0], RequestDeleteEvent):
+                fqids_to_delete: List[Fqid] = []
                 for event in write_request.events:
                     fqids_to_delete.append(event.fqid)
                 with self.database.get_context():

--- a/datastore/writer/flask_frontend/routes_handler.py
+++ b/datastore/writer/flask_frontend/routes_handler.py
@@ -60,7 +60,8 @@ def write_action_worker():
         raise InvalidRequest("Collection for write_action_worker must be action_worker")
     write_handler = WriteHandler()
     write_handler.write_action_worker(req_json)
-    return ("", 201)
+    return_code = 200 if req_json.get("events") [0]["type"] == "delete" else 201
+    return ("", return_code)
 
 
 @dev_only_route

--- a/datastore/writer/flask_frontend/routes_handler.py
+++ b/datastore/writer/flask_frontend/routes_handler.py
@@ -49,10 +49,14 @@ def write_action_worker():
     if type(request.json) != list:
         raise InvalidRequest("write_action_worker data internally must be a list!")
     req_json = cast(List[Dict[str, Any]], request.json)[0]
-    if len(req_json.get("events", ())) != 1:
+    if len(req_json.get("events", ())) != 1 and any(
+        event["type"] != "delete" for event in req_json.get("events", ())
+    ):
         raise InvalidRequest("write_action_worker may contain only 1 event!")
-    event = req_json["events"][0]
-    if collection_from_fqid(event["fqid"]) != "action_worker":
+    if any(
+        collection_from_fqid(event["fqid"]) != "action_worker"
+        for event in req_json.get("events", ())
+    ):
         raise InvalidRequest("Collection for write_action_worker must be action_worker")
     write_handler = WriteHandler()
     write_handler.write_action_worker(req_json)

--- a/datastore/writer/flask_frontend/routes_handler.py
+++ b/datastore/writer/flask_frontend/routes_handler.py
@@ -60,7 +60,7 @@ def write_action_worker():
         raise InvalidRequest("Collection for write_action_worker must be action_worker")
     write_handler = WriteHandler()
     write_handler.write_action_worker(req_json)
-    return_code = 200 if req_json.get("events") [0]["type"] == "delete" else 201
+    return_code = 200 if req_json.get("events", ())[0]["type"] == "delete" else 201
     return ("", return_code)
 
 

--- a/datastore/writer/postgresql_backend/sql_database_backend_service.py
+++ b/datastore/writer/postgresql_backend/sql_database_backend_service.py
@@ -208,6 +208,14 @@ class SqlDatabaseBackendService:
             use_execute_values=True,
         )
 
+    def write_model_deletes_action_worker(self, fqids: List[Fqid]) -> None:
+        """Physically delete of action_workers"""
+        statement = dedent(
+            """\
+            delete from models where fqid in %s;"""
+        )
+        self.connection.execute(statement, [fqids], use_execute_values=True)
+
     def update_id_sequences(self, max_id_per_collection: Dict[Collection, int]) -> None:
         statement = dedent(
             """\

--- a/datastore/writer/postgresql_backend/sql_database_backend_service.py
+++ b/datastore/writer/postgresql_backend/sql_database_backend_service.py
@@ -210,10 +210,7 @@ class SqlDatabaseBackendService:
 
     def write_model_deletes_action_worker(self, fqids: List[Fqid]) -> None:
         """Physically delete of action_workers"""
-        statement = dedent(
-            """\
-            delete from models where fqid in %s;"""
-        )
+        statement = "delete from models where fqid in %s;"
         self.connection.execute(statement, [fqids], use_execute_values=True)
 
     def update_id_sequences(self, max_id_per_collection: Dict[Collection, int]) -> None:

--- a/tests/writer/system/test_write_action_worker.py
+++ b/tests/writer/system/test_write_action_worker.py
@@ -131,6 +131,7 @@ def test_delete_action_worker_wrong_collection(json_client, data, db_cur):
 
 def test_delete_action_worker_with_2_events(json_client, data, db_cur):
     db_cur.execute("insert into models (fqid, data, deleted) values ('action_worker/1', '{\"data\": \"content1\"}', false), ('action_worker/2', '{\"data\": \"content2\"}', false);")
+    db_cur.connection.commit()
     db_cur.execute("select fqid from models where fqid in ('action_worker/1', 'action_worker/2')")
     result = db_cur.fetchall()
     assert len(result) == 2, "There must be 2 records found"

--- a/tests/writer/system/test_write_action_worker.py
+++ b/tests/writer/system/test_write_action_worker.py
@@ -112,3 +112,43 @@ def test_create_action_worker_wrong_collection(json_client, data, db_cur):
         response.json["error"]["msg"]
         == "Collection for write_action_worker must be action_worker"
     )
+
+def test_delete_action_worker_wrong_collection(json_client, data, db_cur):
+    data = [
+            {
+                "events": [{"type": "delete", "fqid": "topic/1"}],
+                "user_id": 1,
+                "locked_fields": {},
+            }
+        ]
+
+    response = json_client.post(WRITE_ACTION_WORKER_URL, data)
+    assert_response_code(response, 400)
+    assert (
+        response.json["error"]["msg"]
+        == "Collection for write_action_worker must be action_worker"
+    )
+
+def test_delete_action_worker_with_2_events(json_client, data, db_cur):
+    db_cur.execute("insert into models (fqid, data, deleted) values ('action_worker/1', '{\"data\": \"content1\"}', false), ('action_worker/2', '{\"data\": \"content2\"}', false);")
+    db_cur.execute("select fqid from models where fqid in ('action_worker/1', 'action_worker/2')")
+    result = db_cur.fetchall()
+    assert len(result) == 2, "There must be 2 records found"
+
+    data = [
+            {
+                "events": [
+                    {"type": "delete", "fqid": "action_worker/1"},
+                    {"type": "delete", "fqid": "action_worker/2"},
+                ],
+                "user_id": 1,
+                "information": "delete action_workers",
+                "locked_fields": {},
+            }
+        ]
+
+    response = json_client.post(WRITE_ACTION_WORKER_URL, data)
+    assert_response_code(response, 200)
+    db_cur.execute("select fqid from models where fqid in ('action_worker/1', 'action_worker/2')")
+    result = db_cur.fetchall()
+    assert len(result) == 0, "There must be 0 records found"

--- a/tests/writer/system/test_write_action_worker.py
+++ b/tests/writer/system/test_write_action_worker.py
@@ -113,14 +113,15 @@ def test_create_action_worker_wrong_collection(json_client, data, db_cur):
         == "Collection for write_action_worker must be action_worker"
     )
 
+
 def test_delete_action_worker_wrong_collection(json_client, data, db_cur):
     data = [
-            {
-                "events": [{"type": "delete", "fqid": "topic/1"}],
-                "user_id": 1,
-                "locked_fields": {},
-            }
-        ]
+        {
+            "events": [{"type": "delete", "fqid": "topic/1"}],
+            "user_id": 1,
+            "locked_fields": {},
+        }
+    ]
 
     response = json_client.post(WRITE_ACTION_WORKER_URL, data)
     assert_response_code(response, 400)
@@ -129,27 +130,36 @@ def test_delete_action_worker_wrong_collection(json_client, data, db_cur):
         == "Collection for write_action_worker must be action_worker"
     )
 
+
 def test_delete_action_worker_with_2_events(json_client, data, db_cur):
-    db_cur.execute("insert into models (fqid, data, deleted) values ('action_worker/1', '{\"data\": \"content1\"}', false), ('action_worker/2', '{\"data\": \"content2\"}', false);")
+    db_cur.execute(
+        "insert into models (fqid, data, deleted) values"
+        " ('action_worker/1', '{\"data\": \"content1\"}', false),"
+        " ('action_worker/2', '{\"data\": \"content2\"}', false);"
+    )
     db_cur.connection.commit()
-    db_cur.execute("select fqid from models where fqid in ('action_worker/1', 'action_worker/2')")
+    db_cur.execute(
+        "select fqid from models where fqid in ('action_worker/1', 'action_worker/2')"
+    )
     result = db_cur.fetchall()
     assert len(result) == 2, "There must be 2 records found"
 
     data = [
-            {
-                "events": [
-                    {"type": "delete", "fqid": "action_worker/1"},
-                    {"type": "delete", "fqid": "action_worker/2"},
-                ],
-                "user_id": 1,
-                "information": "delete action_workers",
-                "locked_fields": {},
-            }
-        ]
+        {
+            "events": [
+                {"type": "delete", "fqid": "action_worker/1"},
+                {"type": "delete", "fqid": "action_worker/2"},
+            ],
+            "user_id": 1,
+            "information": "delete action_workers",
+            "locked_fields": {},
+        }
+    ]
 
     response = json_client.post(WRITE_ACTION_WORKER_URL, data)
     assert_response_code(response, 200)
-    db_cur.execute("select fqid from models where fqid in ('action_worker/1', 'action_worker/2')")
+    db_cur.execute(
+        "select fqid from models where fqid in ('action_worker/1', 'action_worker/2')"
+    )
     result = db_cur.fetchall()
     assert len(result) == 0, "There must be 0 records found"


### PR DESCRIPTION
Lets use the write_action_worker route also for delete-events.

delete tests fail in datastore-tests  and backend action_worker-tests