### PR TITLE
remove debugpy from development Dockerfile

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -25,4 +25,4 @@ ENV PORT=$PORT
 EXPOSE $PORT
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD exec python -m flask run -h 0.0.0.0 -p $PORT
+CMD exec python -m debugpy --listen 0.0.0.0:5678 -m flask run -h 0.0.0.0 -p $PORT --no-reload


### PR DESCRIPTION
As of https://flask.palletsprojects.com/en/2.1.x/debugging/#external-debuggers it can cause unexpected behavior when using flask reload while an external debugger is attached. 
Therefore I removed debugpy from the dev Docker image. This is necessary because the datastore is currently crashing. 