### PR TITLE
Remove caching for current migration index in ReadDatabase

### DIFF
--- a/datastore/migrations/core/migration_handler.py
+++ b/datastore/migrations/core/migration_handler.py
@@ -260,7 +260,9 @@ class MigrationHandlerImplementation(MigrationHandler):
         elif state == MigrationState.MIGRATION_REQUIRED:
             self.event_migrater.migrate()
 
-        current_mi = self.read_database.get_current_migration_index()
+        with self.connection.get_connection_context():
+            current_mi = self.read_database.get_current_migration_index()
+
         if current_mi < self.last_event_migration_target_index:
             self.delete_collectionfield_aux_tables()
 

--- a/datastore/migrations/core/migration_handler.py
+++ b/datastore/migrations/core/migration_handler.py
@@ -210,8 +210,7 @@ class MigrationHandlerImplementation(MigrationHandler):
         return False
 
     def assert_valid_migration_index(self) -> None:
-        # assert untouched db and assert consistent migration index
-        self.read_database.reset()
+        # assert consistent migration index
         try:
             max_db_mi = self.read_database.get_current_migration_index()
         except InvalidDatastoreState as e:
@@ -314,8 +313,6 @@ class MigrationHandlerImplementation(MigrationHandler):
             "update positions set migration_index=%s",
             [target_migration_index],
         )
-        # update migration index cache
-        self.read_database.reset()
 
     def _delete_migration_keyframes(self) -> None:
         self.logger.info("Deleting all migration keyframes...")

--- a/datastore/shared/services/read_database.py
+++ b/datastore/shared/services/read_database.py
@@ -170,6 +170,3 @@ class ReadDatabase(Protocol):
         Returns the maximum migration index from all positions or -1 if there are
         no positions.
         """
-
-    def reset(self) -> None:
-        """Resets the internal state of the database."""

--- a/tests/shared/unit/postgresql_backend/test_sql_read_database_backend_service.py
+++ b/tests/shared/unit/postgresql_backend/test_sql_read_database_backend_service.py
@@ -354,15 +354,3 @@ def test_json(read_database: ReadDatabase, connection: ConnectionHandler):
 
     assert read_database.json(data) == value
     tj.assert_called_with(data)
-
-
-def test_get_current_migration_index_cached(
-    read_database: ReadDatabase, connection: ConnectionHandler
-):
-    connection.query = query = MagicMock(return_value=[[None, None]])
-    assert read_database.get_current_migration_index() == -1
-    query.assert_called_once()
-
-    # second try; now it should be cached (so still called only once)
-    assert read_database.get_current_migration_index() == -1
-    query.assert_called_once()

--- a/tests/writer/system/write/test_migration_index.py
+++ b/tests/writer/system/write/test_migration_index.py
@@ -2,12 +2,7 @@ import copy
 
 import pytest
 
-from datastore.shared.di import injector
 from datastore.shared.flask_frontend import ERROR_CODES
-from datastore.shared.postgresql_backend.sql_read_database_backend_service import (
-    MIGRATION_INDEX_NOT_INITIALIZED,
-)
-from datastore.shared.services import ReadDatabase
 from datastore.writer.flask_frontend.routes import WRITE_URL
 from tests.util import assert_error_response, assert_response_code
 from tests.writer.system.util import assert_model
@@ -45,7 +40,6 @@ def test_use_current_migration_index(
     # change the migration index and reset the read DB
     db_cur.execute("update positions set migration_index=3 where position=1", [])
     db_connection.commit()
-    injector.get(ReadDatabase).current_migration_index = MIGRATION_INDEX_NOT_INITIALIZED
 
     data["events"][0] = {"type": "update", "fqid": "a/1", "fields": {"f": 2}}
     response = json_client.post(WRITE_URL, [data])
@@ -71,7 +65,6 @@ def test_varying_migration_indices(
     # modify the migration index of the second position and reset the read db
     db_cur.execute("update positions set migration_index=3 where position=2", [])
     db_connection.commit()
-    injector.get(ReadDatabase).current_migration_index = MIGRATION_INDEX_NOT_INITIALIZED
 
     data["events"][0] = {"type": "update", "fqid": "a/1", "fields": {"f": 3}}
     response = json_client.post(WRITE_URL, [data])


### PR DESCRIPTION
I think the way it was meant to be is that you shut down all containers except for the manage backend where the migrations are being run, run the migrations, and then start all other containers again. This way, everything works correctly. But if the datastore stays up during the migration (which happens in the backend), it has no way of knowing that the migration happened and will therefore still use the old migration index.

There is no reason that this should not have happened before - the responsive code has stayed the same for at least a year. Maybe you changed something about your instance setup workflow that made this error appear?

Anyway, to prevent this in the future, I removed the caching alltogether. This requires one more SQL query for each write request, but I think this is negligible. As stated above, there is no easy way for the datastore to be informed if a migration happened; one would have to implement e.g. a dedicated route or a DB trigger for it, which is not worth it IMO. Please test if that fixes your error @m-schieder.