### PR TITLE
Use postgres 15 images + debian bookworm images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-buster
+FROM python:3.10.12-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-buster
+FROM python:3.10.12-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-buster
+FROM python:3.10.12-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it vim gcc libpq-dev libc-dev postgresql-client redis-tools curl

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim-buster
+FROM python:3.10.12-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it vim gcc libpq-dev libc-dev postgresql-client redis-tools curl

--- a/dc.dev.yml
+++ b/dc.dev.yml
@@ -36,7 +36,7 @@ services:
         stdin_open: true
         tty: true
     postgres:
-        image: postgres:13
+        image: postgres:15
         env_file: database.env
         networks:
             - postgres

--- a/dc.external.yml
+++ b/dc.external.yml
@@ -39,7 +39,7 @@ services:
             - postgres
             - redis
     postgres:
-        image: postgres:13
+        image: postgres:15
         environment:
             - POSTGRES_USER=openslides
             - POSTGRES_PASSWORD=openslides

--- a/dc.test.yml
+++ b/dc.test.yml
@@ -22,7 +22,7 @@ services:
         ports:
             - "5679:5678"
     postgres:
-        image: postgres:13
+        image: postgres:15
         env_file: database.env
         networks:
             - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         secrets:
             - postgres_password
     postgres:
-        image: postgres:13
+        image: postgres:15
         env_file: database.env
         networks:
             - postgres

--- a/system_tests/Dockerfile
+++ b/system_tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-bookworm
+FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools

--- a/system_tests/Dockerfile
+++ b/system_tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.3-slim-buster
+FROM python:3.10.3-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools


### PR DESCRIPTION
Apart from debian being sensical on it's own, buster packages include postgres software for v11 - bookworm does for v15.