### PR TITLE
Fix locked fields & dev setup

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -16,7 +16,7 @@ COPY $MODULE/entrypoint.sh ./
 ENV PYTHONPATH /app/
 
 ENV FLASK_APP=datastore.$MODULE.app
-ENV FLASK_ENV=development
+ENV FLASK_DEBUG=1
 
 ARG PORT
 RUN test -n "$PORT" || (echo "PORT not set" && false)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,7 +16,7 @@ COPY $MODULE/entrypoint.sh ./
 ENV PYTHONPATH /app/
 
 ENV FLASK_APP=datastore.$MODULE.app
-ENV FLASK_ENV=development
+ENV FLASK_DEBUG=1
 
 ARG PORT
 RUN test -n "$PORT" || (echo "PORT not set" && false)

--- a/datastore/writer/postgresql_backend/sql_occ_locker_backend_service.py
+++ b/datastore/writer/postgresql_backend/sql_occ_locker_backend_service.py
@@ -134,8 +134,12 @@ class SqlOccLockerBackendService:
                     )
                     filter_part = "(e.position>%s and cf.collectionfield=%s"
                     if lock.filter:
-                        filter_part += " and " + self.query_helper.build_filter_str(
-                            lock.filter, query_arguments, "m"
+                        filter_part += (
+                            " and ("
+                            + self.query_helper.build_filter_str(
+                                lock.filter, query_arguments, "m"
+                            )
+                            + ")"
                         )
                     filter_part += ")"
                     filter_parts.append(filter_part)

--- a/scripts/start-flask.sh
+++ b/scripts/start-flask.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-export FLASK_APP=writer/app.py
-flask run --host=0.0.0.0

--- a/tests/shared/unit/util/test_key_types.py
+++ b/tests/shared/unit/util/test_key_types.py
@@ -135,7 +135,3 @@ def test_id():
 
 def test_field():
     assert_is_field("my_field_2_")
-
-
-def test_field_template():
-    assert_is_field("f_$_s")

--- a/tests/writer/system/write/test_occ_locking.py
+++ b/tests/writer/system/write/test_occ_locking.py
@@ -355,125 +355,28 @@ def test_lock_collectionfield_multiple_locks_not_ok(json_client, data):
     assert_no_model("a/2")
 
 
-# Template fields
-
-
-def test_lock_fqfield_template_with_suffix_locked(json_client, data):
-    create_and_update_model(
-        json_client, "a/1", {"f_$1_s": 1, "f_$_s": ["1"]}, {"f_$1_s": 2, "f_$_s": ["2"]}
-    )
-    data["locked_fields"]["a/1/f_$_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
-    assert_no_model("a/2")
-
-
-def test_lock_fqfield_template_dollar_sign(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$_s": 1}, {"f_$_s": 2})
-    data["locked_fields"]["a/1/f_$_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
-    assert_no_model("a/2")
-
-
-def test_lock_fqfield_template_two_placeholders(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_1_2_s": 1}, {"f_1_2_s": 2})
-    data["locked_fields"]["a/1/f_$_$_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_error_response(response, ERROR_CODES.INVALID_FORMAT)
-    assert_no_model("a/2")
-
-
-def test_lock_fqfield_template_empty_placeholder(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f__s": 1}, {"f__s": 2})
-    data["locked_fields"]["a/1/f_$_s"] = 1
+def test_lock_collectionfield_with_or_filter(json_client, data):
+    create_and_update_model(json_client, "a/1", {"f1": 1}, {"f1": 2})
+    data["locked_fields"]["a/f2"] = [
+        {
+            "position": 2,
+            "filter": {
+                "or_filter": [
+                    {
+                        "field": "f1",
+                        "operator": "=",
+                        "value": 1,
+                    },
+                    {
+                        "field": "f1",
+                        "operator": "=",
+                        "value": 2,
+                    },
+                ]
+            },
+        },
+    ]
 
     response = json_client.post(WRITE_URL, data)
     assert_response_code(response, 201)
     assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_other_field_locked(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$1": 1}, {"f_$1": 2})
-    data["locked_fields"]["a/1/f_$2"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_response_code(response, 201)
-    assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_other_field_locked_2(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$1": 1}, {"f_$1": 2})
-    data["locked_fields"]["a/1/f_$11"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_response_code(response, 201)
-    assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_other_field_locked_3(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$11": 1}, {"f_$11": 2})
-    data["locked_fields"]["a/1/f_$1"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_response_code(response, 201)
-    assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_template_field_locked(json_client, data):
-    create_and_update_model(
-        json_client, "a/1", {"f_$1": 1, "f_$": ["1"]}, {"f_$1": 2, "f_$": ["2"]}
-    )
-    data["locked_fields"]["a/1/f_$"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
-    assert_no_model("a/2")
-
-
-def test_lock_fqfield_template_same_field_locked(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$1": 1}, {"f_$1": 2})
-    data["locked_fields"]["a/1/f_$1"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
-    assert_no_model("a/2")
-
-
-def test_lock_fqfield_template_other_field_with_suffix_locked(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$1_s": 1}, {"f_$1_s": 2})
-    data["locked_fields"]["a/1/f_$2_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_response_code(response, 201)
-    assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_other_field_with_suffix_locked_2(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$1_s": 1}, {"f_$1_s": 2})
-    data["locked_fields"]["a/1/f_$11_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_response_code(response, 201)
-    assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_other_field_with_suffix_locked_3(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$11_s": 1}, {"f_$11_s": 2})
-    data["locked_fields"]["a/1/f_$1_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_response_code(response, 201)
-    assert_model("a/2", {}, 3)
-
-
-def test_lock_fqfield_template_same_field_with_suffix_locked(json_client, data):
-    create_and_update_model(json_client, "a/1", {"f_$1_s": 1}, {"f_$1_s": 2})
-    data["locked_fields"]["a/1/f_$1_s"] = 1
-
-    response = json_client.post(WRITE_URL, data)
-    assert_error_response(response, ERROR_CODES.MODEL_LOCKED)
-    assert_no_model("a/2")


### PR DESCRIPTION
The filter part of the locked fields was not correctly parenthesized, so false positive broken locks could occur when called with multiple collection field filters, as happened in https://github.com/OpenSlides/openslides-client/pull/3101#pullrequestreview-1779842540.

Also, enabling the flask debug mode is now done via `FLASK_DEBUG` instead of via `FLASK_ENV`: https://flask.palletsprojects.com/en/2.3.x/config/#debug-mode

Also removed old template field tests.