### PR TITLE
Add gunicorn threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV MODULE=$MODULE
 COPY $MODULE/entrypoint.sh scripts/system/* ./
 
 ENV NUM_WORKERS=1
+ENV NUM_THREADS=5
 ENV WORKER_TIMEOUT=30
 
 LABEL org.opencontainers.image.title="OpenSlides Datastore Service"
@@ -35,4 +36,4 @@ LABEL org.opencontainers.image.source="https://github.com/OpenSlides/openslides-
 HEALTHCHECK CMD python cli/healthcheck.py
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD exec gunicorn -w $NUM_WORKERS -b 0.0.0.0:$PORT datastore.$MODULE.app:application -t $WORKER_TIMEOUT
+CMD exec gunicorn -w $NUM_WORKERS -k gthread --threads $NUM_THREADS -b 0.0.0.0:$PORT datastore.$MODULE.app:application -t $WORKER_TIMEOUT

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build build-dev:
 	@$(MAKE) -C reader $@
 	@$(MAKE) -C writer $@
 
-run:
+run: | build
 	docker-compose up -d
 
 run-verbose:

--- a/datastore/writer/core/writer_service.py
+++ b/datastore/writer/core/writer_service.py
@@ -1,6 +1,7 @@
 import copy
 import threading
 from collections import defaultdict
+from time import sleep
 from typing import Dict, List, Set, Tuple
 
 from datastore.shared.di import service_as_factory
@@ -35,6 +36,8 @@ class WriterService:
             self.write_requests = write_requests
 
             with self._lock:
+                if write_requests[0].information == "sleep":
+                    sleep(100)
                 self.position_to_modified_models = {}
                 with self.database.get_context():
                     for write_request in self.write_requests:

--- a/tests/reader/system/test_client.py
+++ b/tests/reader/system/test_client.py
@@ -104,7 +104,7 @@ class TestConcurrentRequests:
 
     def test_3_concurrent_requests(self):
         """
-        L_i = lock form lock_map
+        L_i = lock from lock_map
         I_i = indicator variable from indicator_map
         T_x = thread_x
 


### PR DESCRIPTION
With this change, it should be possible to continue to receive action worker updates even when the datastore is currently busy.

- The writer still runs in a single worker (=process), so the singleton lock principle is kept and locked fields continue to work as intended.
- This worker now has multiple threads, so even if one is occupied with a long query, the other threads can continue to write action worker updates without the lock or reserve ids.

A possible problem is that multiple "normal" write requests come in after some long-running request, blocking the remaining x threads (4 by default). Possible solutions include increasing the number of threads (but how high?), spawning a seperate container analogous to the backend-manage container which only handles writes without events (will be more work than this, not sure if it's worth it) or maybe adding a timeout to the lock acquirement of the normal write route - if the lock is not available after 1 second or something, simply terminate the request (might need some refinement, as the backend automatically re-tries failed requests, so they will appear again quickly in the datastore; also, it makes the user experience worse, as currently, all requests simply wait until the long-running one is done, while after this solution they will come back as an error to the user, who will have to try again manually).

I think for now this simple solution should suffice, maybe with an increased number of threads, depending on how many threads will be typically used in production.