### PR TITLE
Revert field regex change

### DIFF
--- a/datastore/shared/util/key_types.py
+++ b/datastore/shared/util/key_types.py
@@ -17,7 +17,7 @@ class KEY_TYPE:
 
 _collection_regex = r"[a-z](?:[a-z_]+[a-z]+)?"
 _id_regex = r"[1-9][0-9]*"
-_field_regex = r"[a-z][a-z0-9_]*"
+_field_regex = r"[a-z][a-z0-9_]*\$?[a-z0-9_]*"  # Keep the template field syntax here to enable backend migration tests
 
 fqid_regex = re.compile(f"^({_collection_regex}){KEYSEPARATOR}({_id_regex})$")
 fqfield_regex = re.compile(


### PR DESCRIPTION
The changes in xy lead to failing migration tests in the backend, as the template fields can no longer be written to the datastore: https://github.com/OpenSlides/openslides-backend/actions/runs/8062514334/job/22022403184

Although not the cleanest solution, I'm reverting this to quickly re-enable the tests.