### PR TITLE
Add cronjob to trim collectionfield tables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10.13-slim-bookworm
 
 RUN apt-get -y update && apt-get -y upgrade && \
-    apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools
+    apt-get install --no-install-recommends -y wait-for-it gcc libpq-dev libc-dev postgresql-client redis-tools cron
 
 WORKDIR /app
 ENV PYTHONPATH /app/
@@ -26,6 +26,8 @@ COPY $MODULE/entrypoint.sh scripts/system/* ./
 
 ENV NUM_WORKERS=1
 ENV WORKER_TIMEOUT=30
+
+RUN echo "0 4 * * * root /app/cron.sh >> /var/log/cron.log 2>&1" > /etc/cron.d/trim-collectionfield-tables
 
 LABEL org.opencontainers.image.title="OpenSlides Datastore Service"
 LABEL org.opencontainers.image.description="Service for OpenSlides which wraps the database, which includes reader and writer functionality."

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY $MODULE/entrypoint.sh scripts/system/* ./
 ENV NUM_WORKERS=1
 ENV WORKER_TIMEOUT=30
 
-RUN echo "0 4 * * * root /app/cron.sh >> /var/log/cron.log 2>&1" > /etc/cron.d/trim-collectionfield-tables
+RUN echo "20 4 * * * root /app/cron.sh >> /var/log/cron.log 2>&1" > /etc/cron.d/trim-collectionfield-tables
 
 LABEL org.opencontainers.image.title="OpenSlides Datastore Service"
 LABEL org.opencontainers.image.description="Service for OpenSlides which wraps the database, which includes reader and writer functionality."

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The datastore can be configured with the following environment variables:
 - `DATASTORE_MAX_RETRIES`: The amount of times a request to the database is retried before giving up. Minimum: 1, Default: 5
 - `DATASTORE_RETRY_TIMEOUT`: How long to wait before retrying a request to the database, in sec as float. Set 0 to disable waiting
   between requests. Default: 0.4
+- `DATASTORE_TRIM_COLLECTIONFIELD_TABLES`: Whether or not to enable the automatic collectionfield
+  table trimming via cronjob to improve performance. Default: 0
 - `OPENSLIDES_DEVELOPMENT`: If set to a truthy value, the datastore runs in development mode (see [development docs](docs/development.md)
   for the implications).
 - `DATASTORE_LOG_LEVEL`: Set the log level for the datastore. If not provided, it defaults to `DEBUG` in development

--- a/cli/trim_collectionfield_tables.py
+++ b/cli/trim_collectionfield_tables.py
@@ -41,6 +41,7 @@ def main(args: list[str] = []):
             ),
             [threshold],
         )
+    print("Trimmed collectionfield tables.")
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
             - "${OPENSLIDES_DATASTORE_WRITER_PORT}:${OPENSLIDES_DATASTORE_WRITER_PORT}"
         environment:
             - PORT=${OPENSLIDES_DATASTORE_WRITER_PORT}
+            - DATASTORE_TRIM_COLLECTIONFIELD_TABLES=1
         depends_on:
             - postgres
             - redis

--- a/scripts/system/cron.sh
+++ b/scripts/system/cron.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd $(dirname $0);
+source /app/environment
 source export-database-variables.sh
 export PYTHONPATH=/app/
 /usr/local/bin/python /app/cli/trim_collectionfield_tables.py

--- a/scripts/system/cron.sh
+++ b/scripts/system/cron.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $(dirname $0);
+source export-database-variables.sh
+export PYTHONPATH=/app/
+/usr/local/bin/python /app/cli/trim_collectionfield_tables.py

--- a/scripts/system/cron.sh
+++ b/scripts/system/cron.sh
@@ -2,6 +2,6 @@
 
 set -a
 
-cd $(dirname $0);
+cd $(dirname $0)
 source /app/environment
 /usr/local/bin/python /app/cli/trim_collectionfield_tables.py

--- a/scripts/system/cron.sh
+++ b/scripts/system/cron.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
+set -a
+
 cd $(dirname $0);
 source /app/environment
-source export-database-variables.sh
-export PYTHONPATH=/app/
 /usr/local/bin/python /app/cli/trim_collectionfield_tables.py

--- a/scripts/system/export-database-variables.sh
+++ b/scripts/system/export-database-variables.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+case $OPENSLIDES_DEVELOPMENT in
+    1|on|On|ON|true|True|TRUE)  export OPENSLIDES_ENVIRONMENT=dev;;
+    *)                          export OPENSLIDES_ENVIRONMENT=prod;;
+esac
+
 export DATABASE_HOST=${DATABASE_HOST:-postgres}
 export DATABASE_PORT=${DATABASE_PORT:-5432}
 export DATABASE_NAME=${DATABASE_NAME:-openslides}
 export DATABASE_USER=${DATABASE_USER:-openslides}
 export DATABASE_PASSWORD_FILE=${DATABASE_PASSWORD_FILE:-/run/secrets/postgres_password}
-case $OPENSLIDES_DEVELOPMENT in
-    1|on|On|ON|true|True|TRUE)  export PGPASSWORD="openslides";;
-    *)                          export PGPASSWORD="$(cat "$DATABASE_PASSWORD_FILE")";;
-esac
+if [ "$OPENSLIDES_ENVIRONMENT" = "dev" ]; then
+    export PGPASSWORD="openslides"
+else
+    export PGPASSWORD="$(cat "$DATABASE_PASSWORD_FILE")"
+fi

--- a/writer/entrypoint.sh
+++ b/writer/entrypoint.sh
@@ -15,4 +15,8 @@ if [ -n "$COMMAND" ]; then
     fi
 fi
 
+if [ "$OPENSLIDES_ENVIRONMENT" = "prod" ]; then
+    cron
+fi
+
 exec "$@"

--- a/writer/entrypoint.sh
+++ b/writer/entrypoint.sh
@@ -16,6 +16,7 @@ if [ -n "$COMMAND" ]; then
 fi
 
 if [ "$OPENSLIDES_ENVIRONMENT" = "prod" ]; then
+    printenv > /app/environment
     cron
 fi
 

--- a/writer/entrypoint.sh
+++ b/writer/entrypoint.sh
@@ -17,6 +17,7 @@ fi
 
 if [ "$OPENSLIDES_ENVIRONMENT" = "prod" ]; then
     printenv > /app/environment
+    echo "Starting cron..."
     cron
 fi
 

--- a/writer/entrypoint.sh
+++ b/writer/entrypoint.sh
@@ -15,7 +15,7 @@ if [ -n "$COMMAND" ]; then
     fi
 fi
 
-if [ "$OPENSLIDES_ENVIRONMENT" = "prod" ]; then
+if [ "$OPENSLIDES_ENVIRONMENT" = "prod" ] && [ -n "$DATASTORE_TRIM_COLLECTIONFIELD_TABLES" ]; then
     printenv > /app/environment
     echo "Starting cron..."
     cron


### PR DESCRIPTION
It seems to be generally frowned upon to run multiple services in one docker container, but I implemented it anyway for now, as it keeps our setup identical and does not require changes to all setup files, e.g., to include a new container. I currently run the script every night at 4am, which is pretty much randomly selected.